### PR TITLE
Integrate Boost regex and cpp-terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(bfvmcpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Stub warnings target required by cpp-terminal
+add_library(Warnings INTERFACE)
+add_library(Warnings::Warnings ALIAS Warnings)
+
+add_subdirectory(cpp-terminal)
+
+set(BOOST_REGEX_STANDALONE ON CACHE BOOL "" FORCE)
+add_subdirectory(regex-develop)
+
 add_executable(bfvmcpp
     main.cxx
     src/vm.cpp
@@ -12,4 +21,9 @@ add_executable(bfvmcpp
 target_include_directories(bfvmcpp PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(bfvmcpp PRIVATE
+    Boost::regex
+    cpp-terminal::cpp-terminal
 )

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -514,7 +514,7 @@ int _execute(std::vector<uint8_t>& cells, size_t& cellptr, std::string& code, bo
     return 0;
 }
 
-int bfvmcpp::execute(std::vector<uint8_t>& cells, size_t& cellptr, std::string& code, bool optimize, int eof, bool dynamicSize, bool term = false)
+int bfvmcpp::execute(std::vector<uint8_t>& cells, size_t& cellptr, std::string& code, bool optimize, int eof, bool dynamicSize, bool term)
 {
     int ret = 0;
     if (dynamicSize) term ? ret = _execute<true, true>(cells, cellptr, code, optimize, eof)


### PR DESCRIPTION
## Summary
- link project against Boost.Regex and cpp-terminal libraries
- enable Boost.Regex standalone mode and stub warnings target
- fix duplicate default argument in vm implementation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68982d389cb88331b0be85f2a7ae3d7f