### PR TITLE
Replace Boost.Regex with std::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ target_compile_options(Warnings INTERFACE
 
 add_subdirectory(cpp-terminal)
 
-set(BOOST_REGEX_STANDALONE ON CACHE BOOL "" FORCE)
-add_subdirectory(regex-develop)
-
 set(PROJECT_SOURCES
     main.cxx
     src/vm.cxx
@@ -36,7 +33,6 @@ target_include_directories(bfvmcpp PRIVATE
 )
 
 target_link_libraries(bfvmcpp PRIVATE
-    Boost::regex
     cpp-terminal::cpp-terminal
     Warnings
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,6 @@ target_include_directories(vm_execute_tests PRIVATE
 )
 
 target_link_libraries(vm_execute_tests PRIVATE
-    Boost::regex
     cpp-terminal::cpp-terminal
     Warnings
 )
@@ -27,7 +26,6 @@ target_include_directories(vm_execute_fuzz PRIVATE
 )
 
 target_link_libraries(vm_execute_fuzz PRIVATE
-    Boost::regex
     cpp-terminal::cpp-terminal
     Warnings
 )


### PR DESCRIPTION
## Summary
- drop Boost.Regex in favor of the C++ standard `<regex>`
- remove Boost.Regex dependency from build scripts

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689a2fef0de88331b1c0b09a56933a55