### PR TITLE
Rename project references to goof2

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -110,12 +110,12 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: bfvmcpp-linux-${{ matrix.simd }}
-          path: build/bfvmcpp
+          name: goof2-linux-${{ matrix.simd }}
+          path: build/goof2
 
       - name: Upload Windows artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: bfvmcpp-windows-${{ matrix.simd }}
-          path: build/bfvmcpp.exe
+          name: goof2-windows-${{ matrix.simd }}
+          path: build/goof2.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(bfvmcpp LANGUAGES CXX)
+project(goof2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -44,22 +44,22 @@ set(PROJECT_SOURCES
     include/repl.hxx
 )
 
-add_executable(bfvmcpp
+add_executable(goof2
     ${PROJECT_SOURCES}
 )
 
-target_include_directories(bfvmcpp PRIVATE
+target_include_directories(goof2 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(bfvmcpp PRIVATE
+target_link_libraries(goof2 PRIVATE
     cpp-terminal::cpp-terminal
     Warnings
 )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(bfvmcpp PRIVATE
+    target_compile_options(goof2 PRIVATE
         $<$<CONFIG:Release>:-Ofast>
         $<$<CONFIG:Release>:-march=native>
         $<$<CONFIG:Release>:-funroll-loops>
@@ -69,12 +69,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         $<$<CONFIG:Release>:-ffunction-sections>
         $<$<CONFIG:Release>:-fdata-sections>
     )
-    target_link_options(bfvmcpp PRIVATE
+    target_link_options(goof2 PRIVATE
         $<$<CONFIG:Release>:-flto>
         $<$<CONFIG:Release>:-Wl,--gc-sections>
         $<$<CONFIG:Release>:-s>
     )
-    set_property(TARGET bfvmcpp PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+    set_property(TARGET goof2 PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 endif()
 
 find_program(CLANG_FORMAT_EXE NAMES clang-format)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bfvmcpp
+# goof2
 An all-in-one Brainfuck development tool/VM
 
 ## Building
@@ -46,7 +46,7 @@ The VM supports selectable cell widths. Use the `--cw` option to choose 8-, 16- 
 cells at startup:
 
 ```sh
-./goof --cw 16 program.bf
+./goof2 --cw 16 program.bf
 ```
 
 ## Memory models

--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -1,5 +1,5 @@
 /*
-    Goof - An optimizing brainfuck VM
+    Goof2 - An optimizing brainfuck VM
     REPL API declarations
     Published under the GNU AGPL-3.0-or-later license
 */
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/style.hpp"
 #include "vm.hxx"
@@ -30,8 +31,7 @@ inline void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr,
         --lastNonEmpty;
     }
     out << "Memory dump:" << '\n'
-        << Term::Style::Underline
-        << "row+col |0  |1  |2  |3  |4  |5  |6  |7  |8  |9  |"
+        << Term::Style::Underline << "row+col |0  |1  |2  |3  |4  |5  |6  |7  |8  |9  |"
         << Term::Style::Reset << std::endl;
     size_t end = std::max(lastNonEmpty, std::min(cellPtr, cells.size() - 1));
     for (size_t i = 0, row = 0; i <= end; ++i) {
@@ -41,7 +41,7 @@ inline void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr,
             row += 10;
         }
         out << (i == cellPtr ? Term::color_fg(Term::Color::Name::Green)
-                              : Term::color_fg(Term::Color::Name::Default))
+                             : Term::color_fg(Term::Color::Name::Default))
             << +cells[i] << Term::color_fg(Term::Color::Name::Default)
             << std::string(3 - std::to_string(cells[i]).length(), ' ') << "|";
     }
@@ -51,16 +51,16 @@ inline void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr,
 template <typename CellT>
 inline void executeExcept(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
                           bool optimize, int eof, bool dynamicSize, bool term = false) {
-    int ret = bfvmcpp::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, term);
+    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, term);
     switch (ret) {
         case 1:
-            std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                      << Term::color_fg(Term::Color::Name::Default)
+            std::cout << Term::color_fg(Term::Color::Name::Red)
+                      << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                       << " Unmatched close bracket";
             break;
         case 2:
-            std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                      << Term::color_fg(Term::Color::Name::Default)
+            std::cout << Term::color_fg(Term::Color::Name::Red)
+                      << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                       << " Unmatched open bracket";
             break;
     }

--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -1,20 +1,20 @@
 /*
-    Goof - An optimizing brainfuck VM
+    Goof2 - An optimizing brainfuck VM
     VM API declarations
     Published under the GNU AGPL-3.0-or-later license
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
-#define BFVMCPP_DEFAULT_EOF_BEHAVIOUR 0
-#define BFVMCPP_DYNAMIC_CELLS_SIZE 1
-#define BFVMCPP_OPTIMIZE 1
-#define BFVMCPP_DEFAULT_SAVE_STATE 0
+#define GOOF2_DEFAULT_EOF_BEHAVIOUR 0
+#define GOOF2_DYNAMIC_CELLS_SIZE 1
+#define GOOF2_OPTIMIZE 1
+#define GOOF2_DEFAULT_SAVE_STATE 0
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
-namespace bfvmcpp {
+namespace goof2 {
 /// @brief Only function you should use in your code. For now, it always prints to stdout.
 /// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
 /// @param cells Vector of cells of type CellT.
@@ -22,14 +22,14 @@ namespace bfvmcpp {
 /// @param code Remember that this will be modified, so if you need to do something else with your
 /// plaintext code, make a copy.
 /// @param optimize Enable optimizations (highly recommended). Set it here as an override, for the
-/// default state, check the BFVMCPP_OPTIMIZE define.
+/// default state, check the GOOF2_OPTIMIZE define.
 /// @param eof EOF behaviour. 0 = cell unchanged, 1 = set to 0, 2 = set to 255. Check
-/// BFVMCPP_DEFAULT_EOF_BEHAVIOUR.
+/// GOOF2_DEFAULT_EOF_BEHAVIOUR.
 /// @param dynamicSize Allow dynamic resizing of the cells vector. Disable if you want, for example,
 /// a constant number of decimals for a calculation, constant cell vector size. OOB on fixed size is
 /// currently not handled.
 /// @param term A few tweaks necessary to make it operable multiple times on the same cells. Check
-/// BFVMCPP_DEFAULT_SAVE_STATE.
+/// GOOF2_DEFAULT_SAVE_STATE.
 ///
 /// When dynamicSize is enabled the engine heuristically selects between a contiguous
 /// growth strategy, a Fibonacci-sized expansion scheme and a page-sized allocation
@@ -37,6 +37,6 @@ namespace bfvmcpp {
 /// @return
 template <typename CellT>
 int execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
-            bool optimize = BFVMCPP_OPTIMIZE, int eof = BFVMCPP_DEFAULT_EOF_BEHAVIOUR,
-            bool dynamicSize = BFVMCPP_DYNAMIC_CELLS_SIZE, bool term = BFVMCPP_DEFAULT_SAVE_STATE);
-}  // namespace bfvmcpp
+            bool optimize = GOOF2_OPTIMIZE, int eof = GOOF2_DEFAULT_EOF_BEHAVIOUR,
+            bool dynamicSize = GOOF2_DYNAMIC_CELLS_SIZE, bool term = GOOF2_DEFAULT_SAVE_STATE);
+}  // namespace goof2

--- a/main.cxx
+++ b/main.cxx
@@ -1,5 +1,5 @@
 /*
-    Goof - An optimizing brainfuck VM
+    Goof2 - An optimizing brainfuck VM
     Version 1.4.0
 
     Made by M.K.
@@ -17,9 +17,9 @@
 #include <vector>
 
 #include "argh.hxx"
-#include "include/vm.hxx"
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/style.hpp"
+#include "include/vm.hxx"
 #include "repl.hxx"
 
 #ifdef _WIN32
@@ -54,8 +54,8 @@ int main(int argc, char* argv[]) {
     int cwArg = 8;
     cmdl("cw", 8) >> cwArg;
     if (tsArg <= 0) {
-        std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                  << Term::color_fg(Term::Color::Name::Default)
+        std::cout << Term::color_fg(Term::Color::Name::Red)
+                  << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                   << " Tape size must be positive; using default 30000" << std::endl;
         tsArg = 30000;
     }
@@ -72,15 +72,15 @@ int main(int argc, char* argv[]) {
         if (!filename.empty()) {
             std::ifstream in(filename, std::ios::binary);
             if (!in.is_open()) {
-                std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                          << Term::color_fg(Term::Color::Name::Default)
+                std::cout << Term::color_fg(Term::Color::Name::Red)
+                          << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                           << " File could not be opened";
             } else {
                 std::string code((std::istreambuf_iterator<char>(in)),
                                  std::istreambuf_iterator<char>());
                 if (!in && !in.eof()) {
-                    std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                              << Term::color_fg(Term::Color::Name::Default)
+                    std::cout << Term::color_fg(Term::Color::Name::Red)
+                              << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                               << " Error while reading file";
                 } else {
                     executeExcept<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize);
@@ -106,8 +106,8 @@ int main(int argc, char* argv[]) {
             run(uint64_t{});
             break;
         default:
-            std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
-                      << Term::color_fg(Term::Color::Name::Default)
+            std::cout << Term::color_fg(Term::Color::Name::Red)
+                      << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                       << " Unsupported cell width; use 8,16,32,64" << std::endl;
             return 1;
     }

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -1,5 +1,5 @@
 /*
-    Goof - An optimizing brainfuck VM
+    Goof2 - An optimizing brainfuck VM
     TUI REPL implementation
     Published under the GNU AGPL-3.0-or-later license
 */
@@ -17,8 +17,8 @@
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
 #include "cpp-terminal/terminal.hpp"
-#include "cpp-terminal/window.hpp"
 #include "cpp-terminal/terminfo.hpp"
+#include "cpp-terminal/window.hpp"
 #include "include/vm.hxx"
 
 namespace {

--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -1,5 +1,5 @@
 /*
-    Goof - An optimizing brainfuck VM
+    Goof2 - An optimizing brainfuck VM
     VM implementation
     Published under the GNU AGPL-3.0-or-later license
 */
@@ -25,9 +25,9 @@
 #endif
 
 #if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
-#define BFVMCPP_HAS_OS_VM 1
+#define GOOF2_HAS_OS_VM 1
 #else
-#define BFVMCPP_HAS_OS_VM 0
+#define GOOF2_HAS_OS_VM 0
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -709,7 +709,7 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
     CellT* cellBase = cells.data();
     CellT* cell = cellBase + cellPtr;
     size_t osSize = cells.size();
-#if BFVMCPP_HAS_OS_VM
+#if GOOF2_HAS_OS_VM
     if (model == MemoryModel::OSBacked) {
 #ifdef _WIN32
         CellT* osMem = static_cast<CellT*>(VirtualAlloc(nullptr, osSize * sizeof(CellT),
@@ -744,7 +744,7 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
         size_t needed = static_cast<size_t>(neededIndex + 1);
         switch (model) {
             case MemoryModel::OSBacked: {
-#if BFVMCPP_HAS_OS_VM
+#if GOOF2_HAS_OS_VM
                 size_t newSize = ((needed + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
                 if (newSize > osSize) {
 #ifdef _WIN32
@@ -1007,7 +1007,7 @@ _SCN_LFT: {
 
 _END: {
     ptrdiff_t finalIndex = cell - cellBase;
-#if BFVMCPP_HAS_OS_VM
+#if GOOF2_HAS_OS_VM
     if (model == MemoryModel::OSBacked && cellBase != cells.data()) {
         cells.assign(cellBase, cellBase + osSize);
 #ifdef _WIN32
@@ -1028,8 +1028,8 @@ _END: {
 }
 
 template <typename CellT>
-int bfvmcpp::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
-                     int eof, bool dynamicSize, bool term) {
+int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
+                   int eof, bool dynamicSize, bool term) {
     int ret = 0;
     MemoryModel model = MemoryModel::Contiguous;
     // Heuristic: small tapes use contiguous doubling, medium tapes use
@@ -1037,7 +1037,7 @@ int bfvmcpp::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& co
     // switch to fixed-size paged allocation, and very large tapes use
     // OS-backed virtual memory when available.
     if (dynamicSize) {
-#if BFVMCPP_HAS_OS_VM
+#if GOOF2_HAS_OS_VM
         if (cells.size() > (1u << 28))
             model = MemoryModel::OSBacked;
         else
@@ -1057,11 +1057,11 @@ int bfvmcpp::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& co
     return ret;
 }
 
-template int bfvmcpp::execute<uint8_t>(std::vector<uint8_t>&, size_t&, std::string&, bool, int,
-                                       bool, bool);
-template int bfvmcpp::execute<uint16_t>(std::vector<uint16_t>&, size_t&, std::string&, bool, int,
-                                        bool, bool);
-template int bfvmcpp::execute<uint32_t>(std::vector<uint32_t>&, size_t&, std::string&, bool, int,
-                                        bool, bool);
-template int bfvmcpp::execute<uint64_t>(std::vector<uint64_t>&, size_t&, std::string&, bool, int,
-                                        bool, bool);
+template int goof2::execute<uint8_t>(std::vector<uint8_t>&, size_t&, std::string&, bool, int, bool,
+                                     bool);
+template int goof2::execute<uint16_t>(std::vector<uint16_t>&, size_t&, std::string&, bool, int,
+                                      bool, bool);
+template int goof2::execute<uint32_t>(std::vector<uint32_t>&, size_t&, std::string&, bool, int,
+                                      bool, bool);
+template int goof2::execute<uint64_t>(std::vector<uint64_t>&, size_t&, std::string&, bool, int,
+                                      bool, bool);

--- a/tests/fuzz_execute.cxx
+++ b/tests/fuzz_execute.cxx
@@ -60,7 +60,7 @@ int main() {
         auto *coutbuf = std::cout.rdbuf(out.rdbuf());
         std::cin.clear();
         try {
-            bfvmcpp::execute<uint8_t>(cells, ptr, code, true, 0, true, false);
+            goof2::execute<uint8_t>(cells, ptr, code, true, 0, true, false);
         } catch (...) {
         }
         std::cin.rdbuf(cinbuf);

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -1,4 +1,3 @@
-#include "vm.hxx"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -7,15 +6,17 @@
 #include <string>
 #include <vector>
 
+#include "vm.hxx"
+
 static std::string run(std::string code, std::vector<uint8_t>& cells, size_t& cellPtr,
-                       const std::string& input = "", int eof = 0,
-                       bool dynamicSize = true, int* retOut = nullptr) {
+                       const std::string& input = "", int eof = 0, bool dynamicSize = true,
+                       int* retOut = nullptr) {
     std::istringstream in(input);
     std::ostringstream out;
     auto* cinbuf = std::cin.rdbuf(in.rdbuf());
     auto* coutbuf = std::cout.rdbuf(out.rdbuf());
     std::cin.clear();
-    int ret = bfvmcpp::execute<uint8_t>(cells, cellPtr, code, true, eof, dynamicSize, false);
+    int ret = goof2::execute<uint8_t>(cells, cellPtr, code, true, eof, dynamicSize, false);
     if (retOut) *retOut = ret;
     std::cin.rdbuf(cinbuf);
     std::cout.rdbuf(coutbuf);


### PR DESCRIPTION
## Summary
- rename project target and executable to goof2
- update namespaces, macros, and documentation to use goof2
- adjust CI artifact names for goof2 builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689a3d2fd0048331a22301e99191fa17