### PR TITLE
Add install rules and package export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,27 @@ target_link_libraries(goof2 PRIVATE
     Warnings
 )
 
+install(TARGETS goof2
+    EXPORT goof2Targets
+    RUNTIME DESTINATION bin
+)
+
+install(FILES include/*.hxx DESTINATION include/goof2)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/goof2Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/goof2Config.cmake
+    INSTALL_DESTINATION lib/cmake/goof2
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/goof2Config.cmake
+    DESTINATION lib/cmake/goof2
+)
+install(EXPORT goof2Targets
+    FILE goof2Targets.cmake
+    NAMESPACE goof2::
+    DESTINATION lib/cmake/goof2
+)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(goof2 PRIVATE
         $<$<CONFIG:Release>:-Ofast>

--- a/cmake/goof2Config.cmake.in
+++ b/cmake/goof2Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/goof2Targets.cmake")
+


### PR DESCRIPTION
## Summary
- install `goof2` executable and public headers
- export CMake targets and config to enable `find_package(goof2)`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a566a97f88331801d64af8a6d11bb