### PR TITLE
Refactor execute tests for multiple cell types

### DIFF
--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -2,13 +2,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "vm.hxx"
 
-static std::string run(std::string code, std::vector<uint8_t>& cells, size_t& cellPtr,
+template <typename CellT>
+static std::string run(std::string code, std::vector<CellT>& cells, size_t& cellPtr,
                        const std::string& input = "", int eof = 0, bool dynamicSize = true,
                        int* retOut = nullptr) {
     std::istringstream in(input);
@@ -16,80 +18,93 @@ static std::string run(std::string code, std::vector<uint8_t>& cells, size_t& ce
     auto* cinbuf = std::cin.rdbuf(in.rdbuf());
     auto* coutbuf = std::cout.rdbuf(out.rdbuf());
     std::cin.clear();
-    int ret = goof2::execute<uint8_t>(cells, cellPtr, code, true, eof, dynamicSize, false);
+    int ret = goof2::execute<CellT>(cells, cellPtr, code, true, eof, dynamicSize, false);
     if (retOut) *retOut = ret;
     std::cin.rdbuf(cinbuf);
     std::cout.rdbuf(coutbuf);
     return out.str();
 }
 
+template <typename CellT>
 static void test_loops() {
-    std::vector<uint8_t> cells(2, 0);
+    std::vector<CellT> cells(2, 0);
     size_t ptr = 0;
-    run("++[>++<-]", cells, ptr);
+    run<CellT>("++[>++<-]", cells, ptr);
     assert(cells[0] == 0);
     assert(cells[1] == 4);
 }
 
+template <typename CellT>
 static void test_io() {
-    std::vector<uint8_t> cells(1, 0);
+    std::vector<CellT> cells(1, 0);
     size_t ptr = 0;
-    std::string out = run(",.", cells, ptr, "A");
+    std::string out = run<CellT>(",.", cells, ptr, "A");
     assert(out == "A");
-    assert(cells[0] == static_cast<uint8_t>('A'));
+    assert(cells[0] == static_cast<CellT>('A'));
 }
 
+template <typename CellT>
 static void test_wrapping() {
-    std::vector<uint8_t> cells(1, 0);
+    std::vector<CellT> cells(1, 0);
     size_t ptr = 0;
-    run("-", cells, ptr);
-    assert(cells[0] == 255);
+    run<CellT>("-", cells, ptr);
+    assert(cells[0] == std::numeric_limits<CellT>::max());
 }
 
+template <typename CellT>
 static void test_eof_behavior() {
-    std::vector<uint8_t> cells(1, 42);
+    std::vector<CellT> cells(1, 42);
     size_t ptr = 0;
-    run(",", cells, ptr, "", 0);
+    run<CellT>(",", cells, ptr, "", 0);
     assert(cells[0] == 42);
     cells[0] = 42;
-    run(",", cells, ptr, "", 1);
+    run<CellT>(",", cells, ptr, "", 1);
     assert(cells[0] == 0);
     cells[0] = 42;
-    run(",", cells, ptr, "", 2);
-    assert(cells[0] == 255);
+    run<CellT>(",", cells, ptr, "", 2);
+    assert(cells[0] == std::numeric_limits<CellT>::max());
 }
 
+template <typename CellT>
 static void test_boundary_checks() {
     {
-        std::vector<uint8_t> cells(1, 0);
+        std::vector<CellT> cells(1, 0);
         size_t ptr = 0;
         int ret;
-        run("<", cells, ptr, "", 0, true, &ret);
+        run<CellT>("<", cells, ptr, "", 0, true, &ret);
         assert(ret != 0);
     }
     {
-        std::vector<uint8_t> cells(1, 0);
+        std::vector<CellT> cells(1, 0);
         size_t ptr = 0;
         int ret;
-        run(">", cells, ptr, "", 0, false, &ret);
+        run<CellT>(">", cells, ptr, "", 0, false, &ret);
         assert(ret != 0);
     }
     {
-        std::vector<uint8_t> cells(1, 0);
+        std::vector<CellT> cells(1, 0);
         size_t ptr = 0;
         int ret;
-        run(">", cells, ptr, "", 0, true, &ret);
+        run<CellT>(">", cells, ptr, "", 0, true, &ret);
         assert(ret == 0);
         assert(ptr == 1);
         assert(cells.size() > 1);
     }
 }
 
+template <typename CellT>
+static void run_tests() {
+    test_loops<CellT>();
+    test_io<CellT>();
+    test_wrapping<CellT>();
+    test_eof_behavior<CellT>();
+    test_boundary_checks<CellT>();
+}
+
 int main() {
-    test_loops();
-    test_io();
-    test_wrapping();
-    test_eof_behavior();
-    test_boundary_checks();
+    run_tests<uint8_t>();
+    run_tests<uint16_t>();
+    run_tests<uint32_t>();
+    run_tests<uint64_t>();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Templated execute test helpers over cell type
- Instantiate run and tests for uint8_t, uint16_t, uint32_t, and uint64_t

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a564621cc833197eb680c462110bd