### PR TITLE
feat: make REPL optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ elseif(MINGW)
 endif()
 
 option(BUILD_COVERAGE "Enable coverage reporting" OFF)
+option(GOOF2_ENABLE_REPL "Enable interactive REPL" ON)
 
 if(BUILD_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(--coverage -O0 -g)
@@ -39,25 +40,32 @@ target_compile_options(Warnings INTERFACE
 # Disable building tests, examples, docs, and install rules for submodules
 set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(CPPTERMINAL_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(CPPTERMINAL_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
-set(CPPTERMINAL_ENABLE_DOCS OFF CACHE BOOL "" FORCE)
-set(CPPTERMINAL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+if(GOOF2_ENABLE_REPL)
+    set(CPPTERMINAL_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(CPPTERMINAL_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+    set(CPPTERMINAL_ENABLE_DOCS OFF CACHE BOOL "" FORCE)
+    set(CPPTERMINAL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+endif()
 
 FetchContent_Declare(argh
     GIT_REPOSITORY https://github.com/adishavit/argh
     GIT_TAG c3f0d8c8a6dacb00df626b409248a34e3bcd15f5
 )
-FetchContent_Declare(cpp-terminal
-    GIT_REPOSITORY https://github.com/jupyter-xeus/cpp-terminal
-    GIT_TAG dfb5ddf47dca73ce3cb51e3b8a80f2485bb74dff
-)
+if(GOOF2_ENABLE_REPL)
+    FetchContent_Declare(cpp-terminal
+        GIT_REPOSITORY https://github.com/jupyter-xeus/cpp-terminal
+        GIT_TAG dfb5ddf47dca73ce3cb51e3b8a80f2485bb74dff
+    )
+endif()
 FetchContent_Declare(simde
     GIT_REPOSITORY https://github.com/simd-everywhere/simde
     GIT_TAG 7da3fb1d7f9ad859290f7141403036c3c90bf668
 )
 
-FetchContent_MakeAvailable(argh cpp-terminal)
+FetchContent_MakeAvailable(argh)
+if(GOOF2_ENABLE_REPL)
+    FetchContent_MakeAvailable(cpp-terminal)
+endif()
 FetchContent_GetProperties(simde)
 if(NOT simde_POPULATED)
     FetchContent_Populate(simde)
@@ -68,9 +76,13 @@ set(PROJECT_SOURCES
     main.cxx
     src/vm.cxx
     include/vm.hxx
-    src/repl.cxx
-    include/repl.hxx
 )
+if(GOOF2_ENABLE_REPL)
+    list(APPEND PROJECT_SOURCES
+        src/repl.cxx
+        include/repl.hxx
+    )
+endif()
 
 add_executable(goof2
     ${PROJECT_SOURCES}
@@ -83,10 +95,13 @@ target_include_directories(goof2 PRIVATE
 )
 
 target_link_libraries(goof2 PRIVATE
-    cpp-terminal::cpp-terminal
     argh
     Warnings
 )
+if(GOOF2_ENABLE_REPL)
+    target_link_libraries(goof2 PRIVATE cpp-terminal::cpp-terminal)
+    target_compile_definitions(goof2 PRIVATE GOOF2_ENABLE_REPL)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(goof2 PRIVATE

--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -5,6 +5,7 @@
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
+#ifdef GOOF2_ENABLE_REPL
 #include <cstdint>
 #include <iostream>
 #include <ostream>
@@ -77,3 +78,4 @@ extern template int runRepl<uint8_t>(std::vector<uint8_t>&, size_t&, ReplConfig&
 extern template int runRepl<uint16_t>(std::vector<uint16_t>&, size_t&, ReplConfig&);
 extern template int runRepl<uint32_t>(std::vector<uint32_t>&, size_t&, ReplConfig&);
 extern template int runRepl<uint64_t>(std::vector<uint64_t>&, size_t&, ReplConfig&);
+#endif  // GOOF2_ENABLE_REPL

--- a/main.cxx
+++ b/main.cxx
@@ -17,12 +17,15 @@
 #include <vector>
 
 #include "argh.h"
+#include "include/vm.hxx"
+#ifdef GOOF2_ENABLE_REPL
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/style.hpp"
-#include "include/vm.hxx"
 #include "repl.hxx"
+#endif
 
 #ifdef _WIN32
+#ifdef GOOF2_ENABLE_REPL
 #include <windows.h>
 // Enable ANSI escape sequences on Windows terminals
 static void enable_vt_mode() {
@@ -34,7 +37,9 @@ static void enable_vt_mode() {
     SetConsoleMode(hOut, mode);
 }
 #endif
+#endif
 
+#ifdef GOOF2_ENABLE_REPL
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
     enable_vt_mode();
@@ -154,3 +159,115 @@ int main(int argc, char* argv[]) {
     }
     return 0;
 }
+#else   // !GOOF2_ENABLE_REPL
+namespace {
+template <typename CellT>
+void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr) {
+    if (cells.empty()) {
+        std::cout << "Memory dump:\n<empty>" << std::endl;
+        return;
+    }
+    size_t lastNonEmpty = cells.size() - 1;
+    while (lastNonEmpty > cellPtr && lastNonEmpty > 0 && !cells[lastNonEmpty]) {
+        --lastNonEmpty;
+    }
+    std::cout << "Memory dump:" << std::endl;
+    for (size_t i = 0; i <= lastNonEmpty; ++i) {
+        if (i == cellPtr) std::cout << '[';
+        std::cout << +cells[i];
+        if (i == cellPtr) std::cout << ']';
+        std::cout << (i % 10 == 9 ? '\n' : ' ');
+    }
+    if (lastNonEmpty % 10 != 9) std::cout << std::endl;
+}
+
+template <typename CellT>
+void executeExcept(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
+                   int eof, bool dynamicSize) {
+    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, false);
+    switch (ret) {
+        case 1:
+            std::cerr << "ERROR: Unmatched close bracket";
+            break;
+        case 2:
+            std::cerr << "ERROR: Unmatched open bracket";
+            break;
+    }
+}
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    argh::parser cmdl(argc, argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
+
+    std::string filename;
+    cmdl("i", "") >> filename;
+    const bool dumpMemoryFlag = cmdl["dm"];
+    const bool help = cmdl["h"];
+    bool optimize = !cmdl["nopt"];
+    bool dynamicSize = cmdl["dts"];
+    int eof = 0;
+    std::size_t tapeSize = 30000;
+    int cellWidth = 8;
+    cmdl("eof", 0) >> eof;
+    cmdl("ts", 30000) >> tapeSize;
+    cmdl("cw", 8) >> cellWidth;
+    if (tapeSize == 0) {
+        std::cout << "ERROR: Tape size must be positive; using default 30000" << std::endl;
+        tapeSize = 30000;
+    }
+    std::size_t requiredMem = tapeSize * (cellWidth / 8);
+    if (requiredMem > GOOF2_TAPE_WARN_BYTES) {
+        std::cout << "WARNING: Tape allocation ~" << (requiredMem >> 20)
+                  << " MiB may exceed system memory" << std::endl;
+    }
+    if (help) {
+        std::cout << "Usage: " << argv[0] << " [options]" << std::endl;
+        return 0;
+    }
+    if (filename.empty()) {
+        std::cout << "REPL disabled; use -i <file> to run a program" << std::endl;
+        return 0;
+    }
+    size_t cellPtr = 0;
+    std::ifstream in(filename, std::ios::binary);
+    if (!in.is_open()) {
+        std::cerr << "ERROR: File could not be opened";
+        return 1;
+    }
+    std::string code((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    if (!in && !in.eof()) {
+        std::cerr << "ERROR: Error while reading file";
+        return 1;
+    }
+    switch (cellWidth) {
+        case 8: {
+            std::vector<uint8_t> cells(tapeSize, 0);
+            executeExcept<uint8_t>(cells, cellPtr, code, optimize, eof, dynamicSize);
+            if (dumpMemoryFlag) dumpMemory<uint8_t>(cells, cellPtr);
+            break;
+        }
+        case 16: {
+            std::vector<uint16_t> cells(tapeSize, 0);
+            executeExcept<uint16_t>(cells, cellPtr, code, optimize, eof, dynamicSize);
+            if (dumpMemoryFlag) dumpMemory<uint16_t>(cells, cellPtr);
+            break;
+        }
+        case 32: {
+            std::vector<uint32_t> cells(tapeSize, 0);
+            executeExcept<uint32_t>(cells, cellPtr, code, optimize, eof, dynamicSize);
+            if (dumpMemoryFlag) dumpMemory<uint32_t>(cells, cellPtr);
+            break;
+        }
+        case 64: {
+            std::vector<uint64_t> cells(tapeSize, 0);
+            executeExcept<uint64_t>(cells, cellPtr, code, optimize, eof, dynamicSize);
+            if (dumpMemoryFlag) dumpMemory<uint64_t>(cells, cellPtr);
+            break;
+        }
+        default:
+            std::cerr << "ERROR: Unsupported cell width; use 8,16,32,64" << std::endl;
+            return 1;
+    }
+    return 0;
+}
+#endif  // GOOF2_ENABLE_REPL

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -4,6 +4,7 @@
     Published under the GNU AGPL-3.0-or-later license
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
+#ifdef GOOF2_ENABLE_REPL
 #include "repl.hxx"
 
 #include <algorithm>
@@ -296,3 +297,4 @@ template int runRepl<uint8_t>(std::vector<uint8_t>&, size_t&, ReplConfig&);
 template int runRepl<uint16_t>(std::vector<uint16_t>&, size_t&, ReplConfig&);
 template int runRepl<uint32_t>(std::vector<uint32_t>&, size_t&, ReplConfig&);
 template int runRepl<uint64_t>(std::vector<uint64_t>&, size_t&, ReplConfig&);
+#endif  // GOOF2_ENABLE_REPL

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,11 @@ target_include_directories(vm_execute_tests PRIVATE
 )
 
 target_link_libraries(vm_execute_tests PRIVATE
-    cpp-terminal::cpp-terminal
     Warnings
 )
+if(GOOF2_ENABLE_REPL)
+    target_link_libraries(vm_execute_tests PRIVATE cpp-terminal::cpp-terminal)
+endif()
 
 add_test(NAME vm_execute_tests COMMAND vm_execute_tests)
 
@@ -28,6 +30,8 @@ target_include_directories(vm_execute_fuzz PRIVATE
 )
 
 target_link_libraries(vm_execute_fuzz PRIVATE
-    cpp-terminal::cpp-terminal
     Warnings
 )
+if(GOOF2_ENABLE_REPL)
+    target_link_libraries(vm_execute_fuzz PRIVATE cpp-terminal::cpp-terminal)
+endif()


### PR DESCRIPTION
## Summary
- add `GOOF2_ENABLE_REPL` toggle to control building the terminal REPL
- guard REPL sources and cpp-terminal dependency behind the new option
- provide a stripped-down command-line path when REPL is disabled

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `cmake -S . -B build_norepl -DGOOF2_ENABLE_REPL=OFF`
- `cmake --build build_norepl`
- `ctest --test-dir build_norepl`


------
https://chatgpt.com/codex/tasks/task_e_689a562f87048331be0e4dbf017bdac5