### PR TITLE
Handle OS-backed allocation failures

### DIFF
--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -11,11 +11,21 @@
 #define GOOF2_DEFAULT_SAVE_STATE 0
 #define GOOF2_TAPE_WARN_BYTES (1ull << 30)  // 1 GiB
 
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
+#define GOOF2_HAS_OS_VM 1
+#else
+#define GOOF2_HAS_OS_VM 0
+#endif
+
 #include <cstdint>
 #include <string>
 #include <vector>
 
 namespace goof2 {
+#if GOOF2_HAS_OS_VM
+extern void* (*os_alloc)(size_t);
+extern void (*os_free)(void*, size_t);
+#endif
 /// @brief Only function you should use in your code. For now, it always prints to stdout.
 /// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
 /// @param cells Vector of cells of type CellT.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,24 @@ target_link_libraries(vm_execute_tests PRIVATE
 
 add_test(NAME vm_execute_tests COMMAND vm_execute_tests)
 
+add_executable(vm_alloc_fail_tests
+    ${CMAKE_SOURCE_DIR}/src/vm.cxx
+    test_alloc_fail.cxx
+)
+
+target_include_directories(vm_alloc_fail_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}
+    ${SIMDE_INCLUDE_DIR}
+)
+
+target_link_libraries(vm_alloc_fail_tests PRIVATE
+    cpp-terminal::cpp-terminal
+    Warnings
+)
+
+add_test(NAME vm_alloc_fail_tests COMMAND vm_alloc_fail_tests)
+
 add_executable(vm_execute_fuzz
     ${CMAKE_SOURCE_DIR}/src/vm.cxx
     fuzz_execute.cxx

--- a/tests/test_alloc_fail.cxx
+++ b/tests/test_alloc_fail.cxx
@@ -1,0 +1,88 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "vm.hxx"
+
+#if !defined(_WIN32)
+#include <sys/mman.h>
+#endif
+
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
+#define GOOF2_HAS_OS_VM 1
+#else
+#define GOOF2_HAS_OS_VM 0
+#endif
+
+enum class MemoryModel { Contiguous, Paged, Fibonacci, OSBacked };
+
+template <typename CellT, bool Dynamic, bool Term>
+int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
+                int eof, MemoryModel model);
+
+#if GOOF2_HAS_OS_VM
+static void* (*real_alloc)(size_t) = goof2::os_alloc;
+
+static void* always_fail(size_t) {
+#ifdef _WIN32
+    return nullptr;
+#else
+    return MAP_FAILED;
+#endif
+}
+
+static void test_initial_failure() {
+    goof2::os_alloc = always_fail;
+    std::vector<uint8_t> cells(1, 0);
+    size_t ptr = 0;
+    std::string code;
+    std::ostringstream err;
+    auto* old = std::cerr.rdbuf(err.rdbuf());
+    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
+    std::cerr.rdbuf(old);
+    goof2::os_alloc = real_alloc;
+    assert(ret == 0);
+    (void)ret;
+    assert(err.str().find("OS-backed allocation failed") != std::string::npos);
+}
+
+static int call_count = 0;
+static void* succeed_once_then_fail(size_t bytes) {
+    if (call_count++ == 0) return real_alloc(bytes);
+#ifdef _WIN32
+    return nullptr;
+#else
+    return MAP_FAILED;
+#endif
+}
+
+static void test_growth_failure() {
+    call_count = 0;
+    goof2::os_alloc = succeed_once_then_fail;
+    std::vector<uint8_t> cells(1, 0);
+    size_t ptr = 0;
+    std::string code = ">";
+    std::ostringstream err;
+    auto* old = std::cerr.rdbuf(err.rdbuf());
+    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
+    std::cerr.rdbuf(old);
+    goof2::os_alloc = real_alloc;
+    assert(ret == 0);
+    (void)ret;
+    assert(ptr == 1);
+    assert(cells.size() == 65536);
+    assert(err.str().find("OS-backed allocation failed") != std::string::npos);
+}
+#endif
+
+int main() {
+#if GOOF2_HAS_OS_VM
+    test_initial_failure();
+    test_growth_failure();
+#endif
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Guard OS-backed allocations with pluggable allocator functions
- Log warnings and fall back to Contiguous memory model when mmap/VirtualAlloc fails
- Add tests that mock allocator failures to ensure graceful fallback

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a564e13788331832e09c9da2059cb