### PR TITLE
Add memory model expansion test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,26 @@ target_link_libraries(vm_alloc_fail_tests PRIVATE
 
 add_test(NAME vm_alloc_fail_tests COMMAND vm_alloc_fail_tests)
 
+add_executable(vm_memory_model_tests
+    ${CMAKE_SOURCE_DIR}/src/vm.cxx
+    test_memory_models.cxx
+)
+
+target_include_directories(vm_memory_model_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}
+    ${SIMDE_INCLUDE_DIR}
+)
+
+target_link_libraries(vm_memory_model_tests PRIVATE
+    Warnings
+)
+if(GOOF2_ENABLE_REPL)
+    target_link_libraries(vm_memory_model_tests PRIVATE cpp-terminal::cpp-terminal)
+endif()
+
+add_test(NAME vm_memory_model_tests COMMAND vm_memory_model_tests)
+
 add_executable(vm_execute_fuzz
     ${CMAKE_SOURCE_DIR}/src/vm.cxx
     fuzz_execute.cxx

--- a/tests/test_memory_models.cxx
+++ b/tests/test_memory_models.cxx
@@ -1,0 +1,35 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "vm.hxx"
+
+enum class MemoryModel { Contiguous, Paged, Fibonacci, OSBacked };
+
+template <typename CellT, bool Dynamic, bool Term>
+int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
+                int eof, MemoryModel model);
+
+static void run_model(MemoryModel model, size_t expectedSize) {
+    std::vector<uint8_t> cells(1, 0);
+    size_t ptr = 0;
+    std::string code = ">";
+    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, model);
+    (void)ret;
+    assert(ret == 0);
+    assert(ptr == 1);
+    assert(cells.size() == expectedSize);
+    (void)expectedSize;
+}
+
+int main() {
+    run_model(MemoryModel::Contiguous, 2);
+    run_model(MemoryModel::Paged, 2);
+    run_model(MemoryModel::Fibonacci, 2);
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
+    run_model(MemoryModel::OSBacked, 2);
+#endif
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add tests for memory model expansion behavior
- register memory model test in CMake build

## Testing
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a5849b0c8833180f11f01d53b778f