### PR TITLE
Expand SIMD MUL_CPY to wider cell sizes

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -14,6 +14,7 @@
 #include <regex>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #if defined(_WIN32)
@@ -880,11 +881,13 @@ _MUL_CPY:
             ensure(currentCell, neededIndex);
         }
     }
-    if constexpr (std::is_same_v<CellT, uint8_t>) {
-        // Attempt to process sixteen consecutive MUL_CPY instructions at once
+    if constexpr (std::is_same_v<CellT, uint8_t> || std::is_same_v<CellT, uint16_t> ||
+                  std::is_same_v<CellT, uint32_t> || std::is_same_v<CellT, uint64_t>) {
+        constexpr int lanes = std::is_same_v<CellT, uint8_t> ? 16 : (32 / sizeof(CellT));
+        // Attempt to process consecutive MUL_CPY instructions at once
         const instruction* base = insp;
         bool canSimd = true;
-        for (int i = 1; i < 16; ++i) {
+        for (int i = 1; i < lanes; ++i) {
             if (base[i].jump != &&_MUL_CPY || base[i].offset != base[0].offset ||
                 base[i].data != base[0].data + i) {
                 canSimd = false;
@@ -894,27 +897,53 @@ _MUL_CPY:
         if (canSimd) {
             if constexpr (Dynamic) {
                 const ptrdiff_t currentCell = cell - cellBase;
-                const ptrdiff_t neededIndex = currentCell + base[15].offset + base[15].data;
+                const ptrdiff_t neededIndex =
+                    currentCell + base[lanes - 1].offset + base[lanes - 1].data;
                 size_t totalSize = (model == MemoryModel::OSBacked ? osSize : cells.size());
                 if (neededIndex >= static_cast<ptrdiff_t>(totalSize)) {
                     ensure(currentCell, neededIndex);
                 }
             }
-
-            uint8_t src = *(cell + base[0].offset);
-            uint8_t* dst = cell + base[0].offset + base[0].data;
-            alignas(32) int16_t factors[16];
-            for (int i = 0; i < 16; ++i) factors[i] = base[i].auxData;
-            simde__m256i dstv =
-                simde_mm256_cvtepu8_epi16(simde_mm_loadu_si128((const simde__m128i*)dst));
-            simde__m256i srcv = simde_mm256_set1_epi16(src);
-            simde__m256i facv = simde_mm256_loadu_si256((const simde__m256i*)factors);
-            simde__m256i prod = simde_mm256_mullo_epi16(srcv, facv);
-            simde__m256i sum = simde_mm256_add_epi16(dstv, prod);
-            sum = simde_mm256_and_si256(sum, simde_mm256_set1_epi16(0xFF));
-            simde__m256i packed = simde_mm256_packus_epi16(sum, simde_mm256_setzero_si256());
-            simde_mm_storeu_si128((simde__m128i*)dst, simde_mm256_castsi256_si128(packed));
-            insp += 15;  // skip processed instructions
+            CellT src = *(cell + base[0].offset);
+            CellT* dst = cell + base[0].offset + base[0].data;
+            alignas(32) int16_t factors[lanes];
+            for (int i = 0; i < lanes; ++i) factors[i] = base[i].auxData;
+            if constexpr (std::is_same_v<CellT, uint8_t>) {
+                simde__m256i dstv =
+                    simde_mm256_cvtepu8_epi16(simde_mm_loadu_si128((const simde__m128i*)dst));
+                simde__m256i srcv = simde_mm256_set1_epi16(src);
+                simde__m256i facv = simde_mm256_loadu_si256((const simde__m256i*)factors);
+                simde__m256i prod = simde_mm256_mullo_epi16(srcv, facv);
+                simde__m256i sum = simde_mm256_add_epi16(dstv, prod);
+                sum = simde_mm256_and_si256(sum, simde_mm256_set1_epi16(0xFF));
+                simde__m256i packed = simde_mm256_packus_epi16(sum, simde_mm256_setzero_si256());
+                simde_mm_storeu_si128((simde__m128i*)dst, simde_mm256_castsi256_si128(packed));
+            } else if constexpr (std::is_same_v<CellT, uint16_t>) {
+                simde__m256i dstv = simde_mm256_loadu_si256((const simde__m256i*)dst);
+                simde__m256i srcv = simde_mm256_set1_epi16(src);
+                simde__m256i facv = simde_mm256_loadu_si256((const simde__m256i*)factors);
+                simde__m256i prod = simde_mm256_mullo_epi16(srcv, facv);
+                simde__m256i sum = simde_mm256_add_epi16(dstv, prod);
+                simde_mm256_storeu_si256((simde__m256i*)dst, sum);
+            } else if constexpr (std::is_same_v<CellT, uint32_t>) {
+                simde__m256i dstv = simde_mm256_loadu_si256((const simde__m256i*)dst);
+                simde__m256i srcv = simde_mm256_set1_epi32(static_cast<int32_t>(src));
+                simde__m256i facv =
+                    simde_mm256_cvtepi16_epi32(simde_mm_loadu_si128((const simde__m128i*)factors));
+                simde__m256i prod = simde_mm256_mullo_epi32(srcv, facv);
+                simde__m256i sum = simde_mm256_add_epi32(dstv, prod);
+                simde_mm256_storeu_si256((simde__m256i*)dst, sum);
+            } else {
+                using SignedT = std::make_signed_t<CellT>;
+                alignas(32) SignedT prod[lanes];
+                SignedT srcs = static_cast<SignedT>(src);
+                for (int i = 0; i < lanes; ++i) prod[i] = srcs * static_cast<SignedT>(factors[i]);
+                simde__m256i dstv = simde_mm256_loadu_si256((const simde__m256i*)dst);
+                simde__m256i prodv = simde_mm256_loadu_si256((const simde__m256i*)prod);
+                simde__m256i sum = simde_mm256_add_epi64(dstv, prodv);
+                simde_mm256_storeu_si256((simde__m256i*)dst, sum);
+            }
+            insp += lanes - 1;  // skip processed instructions
             LOOP();
         }
     }

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -93,12 +93,30 @@ static void test_boundary_checks() {
 }
 
 template <typename CellT>
+static void test_mul_cpy() {
+    std::vector<CellT> cells(64, 0);
+    size_t ptr = 0;
+    if constexpr (sizeof(CellT) <= 2) {
+        run<CellT>("++++[->+>+>+>+>+>+>+>+>+>+>+>+>+>+>+>+<<<<<<<<<<<<<<<<]", cells, ptr);
+        for (int i = 1; i <= 16; ++i) assert(cells[i] == 4);
+    } else if constexpr (sizeof(CellT) == 4) {
+        run<CellT>("++++[->+>+>+>+>+>+>+>+<<<<<<<<]", cells, ptr);
+        for (int i = 1; i <= 8; ++i) assert(cells[i] == 4);
+    } else {
+        run<CellT>("++++[->+>+>+>+<<<<]", cells, ptr);
+        for (int i = 1; i <= 4; ++i) assert(cells[i] == 4);
+    }
+    assert(cells[0] == 0);
+}
+
+template <typename CellT>
 static void run_tests() {
     test_loops<CellT>();
     test_io<CellT>();
     test_wrapping<CellT>();
     test_eof_behavior<CellT>();
     test_boundary_checks<CellT>();
+    test_mul_cpy<CellT>();
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- generalize SIMD MUL_CPY dispatch to compute lane counts per cell width and include uint64_t cells
- test copy-loop behavior for all cell widths, including 64-bit cells

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a674c08a08331806824fed6928e7c