### PR TITLE
Fix stride left scan bounds

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -353,6 +353,7 @@ static inline size_t simdScan0BackStride(const CellT* base, const CellT* p, unsi
             }
             x -= LANES;
         }
+        phaseAtP = static_cast<unsigned>(x - base) & Mask;
         while (x >= base) {
             if (phaseAtP == 0 && *x == 0) return (size_t)(p - x);
             --x;
@@ -1025,11 +1026,23 @@ _SCN_LFT: {
         unsigned phaseAtP = static_cast<unsigned>(cell - cellBase) & 1u;
         size_t back = simdScan0BackStride<2, CellT>(cellBase, cell, phaseAtP);
         cell -= back;
+        if (cell < cellBase) {
+            cell = cellBase;
+            cellPtr = 0;
+            std::cerr << "cell pointer moved before start" << std::endl;
+            return -1;
+        }
         LOOP();
     } else if (step == 4) {
         unsigned phaseAtP = static_cast<unsigned>(cell - cellBase) & 3u;
         size_t back = simdScan0BackStride<4, CellT>(cellBase, cell, phaseAtP);
         cell -= back;
+        if (cell < cellBase) {
+            cell = cellBase;
+            cellPtr = 0;
+            std::cerr << "cell pointer moved before start" << std::endl;
+            return -1;
+        }
         LOOP();
     } else if (step == 8) {
         unsigned phaseAtP = static_cast<unsigned>(cell - cellBase) & 7u;

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -110,12 +110,41 @@ static void test_mul_cpy() {
 }
 
 template <typename CellT>
+static void test_scan_stride() {
+    {
+        std::vector<CellT> cells(5, 0);
+        cells[4] = 1;
+        cells[2] = 1;
+        size_t ptr = 4;
+        run<CellT>("[<<]", cells, ptr);
+        assert(ptr == 0);
+    }
+    {
+        std::vector<CellT> cells(9, 0);
+        cells[8] = 1;
+        cells[4] = 1;
+        size_t ptr = 8;
+        run<CellT>("[<<<<]", cells, ptr);
+        assert(ptr == 0);
+    }
+    {
+        std::vector<CellT> cells(17, 0);
+        cells[16] = 1;
+        cells[8] = 1;
+        size_t ptr = 16;
+        run<CellT>("[<<<<<<<<]", cells, ptr);
+        assert(ptr == 0);
+    }
+}
+
+template <typename CellT>
 static void run_tests() {
     test_loops<CellT>();
     test_io<CellT>();
     test_wrapping<CellT>();
     test_eof_behavior<CellT>();
     test_boundary_checks<CellT>();
+    test_scan_stride<CellT>();
     test_mul_cpy<CellT>();
 }
 


### PR DESCRIPTION
## Summary
- recompute phase after SIMD block for stride-based backward scans
- guard tiny-stride left scans against moving before the start
- add regression tests for 2-, 4-, and 8-step leftward scans

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a747356c8833197789d6420680946