### PR TITLE
feat: remove argh dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
-[submodule "argh"]
-	path = argh
-	url = https://github.com/adishavit/argh
 [submodule "cpp-terminal"]
-	path = cpp-terminal
-	url = https://github.com/jupyter-xeus/cpp-terminal
+        path = cpp-terminal
+        url = https://github.com/jupyter-xeus/cpp-terminal
 [submodule "simde"]
-	path = simde
-	url = https://github.com/simd-everywhere/simde
+        path = simde
+        url = https://github.com/simd-everywhere/simde

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,6 @@
 ## Licensing
 - The project is licensed under the GNU Affero General Public License v3.0 or later.
 - Third-party components (included via git submodules):
-  - argh (BSD-3-Clause), see `argh/LICENSE`
   - cpp-terminal (MIT), see `cpp-terminal/LICENSE`
   - simde (MIT and CC0), see `simde/COPYING`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ if(GOOF2_ENABLE_REPL)
     set(CPPTERMINAL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 endif()
 
-FetchContent_Declare(argh
-    GIT_REPOSITORY https://github.com/adishavit/argh
-    GIT_TAG c3f0d8c8a6dacb00df626b409248a34e3bcd15f5
-)
 if(GOOF2_ENABLE_REPL)
     FetchContent_Declare(cpp-terminal
         GIT_REPOSITORY https://github.com/jupyter-xeus/cpp-terminal
@@ -62,7 +58,6 @@ FetchContent_Declare(simde
     GIT_TAG 7da3fb1d7f9ad859290f7141403036c3c90bf668
 )
 
-FetchContent_MakeAvailable(argh)
 if(GOOF2_ENABLE_REPL)
     FetchContent_MakeAvailable(cpp-terminal)
 endif()
@@ -95,7 +90,6 @@ target_include_directories(goof2 PRIVATE
 )
 
 target_link_libraries(goof2 PRIVATE
-    argh
     Warnings
 )
 if(GOOF2_ENABLE_REPL)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ The virtual machine grows its cell tape using several strategies:
 
 This project is licensed under the terms of the GNU Affero General Public License v3.0 or later.
 It includes third-party components under separate licenses:
-- argh (BSD-3-Clause), included via git submodule; see `argh/LICENSE`
 - cpp-terminal (MIT), included via git submodule; see `cpp-terminal/LICENSE`
 - simde (MIT and CC0), included via git submodule; see `simde/COPYING`
 

--- a/argh
+++ b/argh
@@ -1,1 +1,0 @@
-Subproject commit c3f0d8c8a6dacb00df626b409248a34e3bcd15f5


### PR DESCRIPTION
## Summary
- replace argh with simple in-tree command-line parser
- drop argh submodule and update build and docs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a7802cf3883318ce877e7ea194ff5