### PR TITLE
Enable parallel LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
+include(ProcessorCount)
+ProcessorCount(LTO_PARALLEL_JOBS)
+if(NOT LTO_PARALLEL_JOBS OR LTO_PARALLEL_JOBS EQUAL 0)
+    set(LTO_PARALLEL_JOBS 1)
+endif()
 
 # Link the C++ runtime statically on Windows to avoid missing procedure
 # entry point errors when running the prebuilt executable.
@@ -128,9 +133,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         $<$<CONFIG:Release>:-fno-semantic-interposition>
         $<$<CONFIG:Release>:-ffunction-sections>
         $<$<CONFIG:Release>:-fdata-sections>
+        $<$<CONFIG:Release>:-flto=${LTO_PARALLEL_JOBS}>
     )
     target_link_options(goof2 PRIVATE
-        $<$<CONFIG:Release>:-flto>
+        $<$<CONFIG:Release>:-flto=${LTO_PARALLEL_JOBS}>
         $<$<CONFIG:Release>:-Wl,--gc-sections>
         $<$<CONFIG:Release>:-s>
     )


### PR DESCRIPTION
## Summary
- Detect host CPU count in CMake and configure link-time optimization to use that many parallel jobs.

## Testing
- `cmake -S . -B build`
- `cmake --build build --parallel 4`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a7cf3a34083318588f8c3e7c86202