### PR TITLE
feat: expose vm as reusable library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,29 +67,39 @@ if(NOT simde_POPULATED)
 endif()
 set(SIMDE_INCLUDE_DIR ${simde_SOURCE_DIR})
 
-set(PROJECT_SOURCES
-    main.cxx
+set(VM_SOURCES
     src/vm.cxx
     include/vm.hxx
 )
+
+add_library(vm ${VM_SOURCES})
+target_include_directories(vm
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/goof2>
+    PRIVATE
+        ${SIMDE_INCLUDE_DIR}
+)
+target_link_libraries(vm PRIVATE Warnings)
+
+set(EXEC_SOURCES
+    main.cxx
+)
 if(GOOF2_ENABLE_REPL)
-    list(APPEND PROJECT_SOURCES
+    list(APPEND EXEC_SOURCES
         src/repl.cxx
         include/repl.hxx
     )
 endif()
 
-add_executable(goof2
-    ${PROJECT_SOURCES}
-)
+set(PROJECT_SOURCES ${EXEC_SOURCES} ${VM_SOURCES})
 
-target_include_directories(goof2 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${SIMDE_INCLUDE_DIR}
+add_executable(goof2
+    ${EXEC_SOURCES}
 )
 
 target_link_libraries(goof2 PRIVATE
+    vm
     Warnings
 )
 if(GOOF2_ENABLE_REPL)
@@ -97,9 +107,11 @@ if(GOOF2_ENABLE_REPL)
     target_compile_definitions(goof2 PRIVATE GOOF2_ENABLE_REPL)
 endif()
 
-install(TARGETS goof2
+install(TARGETS goof2 vm
     EXPORT goof2Targets
     RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
 )
 
 install(FILES include/*.hxx DESTINATION include/goof2)

--- a/main.cxx
+++ b/main.cxx
@@ -13,7 +13,7 @@
 #include <string_view>
 #include <vector>
 
-#include "include/vm.hxx"
+#include "vm.hxx"
 #ifdef GOOF2_ENABLE_REPL
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/style.hpp"

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -21,7 +21,7 @@
 #include "cpp-terminal/terminal.hpp"
 #include "cpp-terminal/terminfo.hpp"
 #include "cpp-terminal/window.hpp"
-#include "include/vm.hxx"
+#include "vm.hxx"
 
 namespace {
 bool supportsColor() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,75 +1,41 @@
 add_executable(vm_execute_tests
-    ${CMAKE_SOURCE_DIR}/src/vm.cxx
     test_execute.cxx
 )
 
-target_include_directories(vm_execute_tests PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}
-    ${SIMDE_INCLUDE_DIR}
-)
-
 target_link_libraries(vm_execute_tests PRIVATE
+    vm
     Warnings
 )
-if(GOOF2_ENABLE_REPL)
-    target_link_libraries(vm_execute_tests PRIVATE cpp-terminal::cpp-terminal)
-endif()
 
 add_test(NAME vm_execute_tests COMMAND vm_execute_tests)
 
 add_executable(vm_alloc_fail_tests
-    ${CMAKE_SOURCE_DIR}/src/vm.cxx
     test_alloc_fail.cxx
 )
 
-target_include_directories(vm_alloc_fail_tests PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}
-    ${SIMDE_INCLUDE_DIR}
-)
-
 target_link_libraries(vm_alloc_fail_tests PRIVATE
-    cpp-terminal::cpp-terminal
+    vm
     Warnings
 )
 
 add_test(NAME vm_alloc_fail_tests COMMAND vm_alloc_fail_tests)
 
 add_executable(vm_memory_model_tests
-    ${CMAKE_SOURCE_DIR}/src/vm.cxx
     test_memory_models.cxx
 )
 
-target_include_directories(vm_memory_model_tests PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}
-    ${SIMDE_INCLUDE_DIR}
-)
-
 target_link_libraries(vm_memory_model_tests PRIVATE
+    vm
     Warnings
 )
-if(GOOF2_ENABLE_REPL)
-    target_link_libraries(vm_memory_model_tests PRIVATE cpp-terminal::cpp-terminal)
-endif()
 
 add_test(NAME vm_memory_model_tests COMMAND vm_memory_model_tests)
 
 add_executable(vm_execute_fuzz
-    ${CMAKE_SOURCE_DIR}/src/vm.cxx
     fuzz_execute.cxx
 )
 
-target_include_directories(vm_execute_fuzz PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}
-    ${SIMDE_INCLUDE_DIR}
-)
-
 target_link_libraries(vm_execute_fuzz PRIVATE
+    vm
     Warnings
 )
-if(GOOF2_ENABLE_REPL)
-    target_link_libraries(vm_execute_fuzz PRIVATE cpp-terminal::cpp-terminal)
-endif()


### PR DESCRIPTION
## Summary
- create standalone vm library and link executable and tests against it
- switch code to include vm header directly for easier reuse

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a7d5891b08331b66b0e575ac92724