### PR TITLE
Integrate templated sparse tape with automatic selection

### DIFF
--- a/tests/test_alloc_fail.cxx
+++ b/tests/test_alloc_fail.cxx
@@ -20,7 +20,7 @@
 
 enum class MemoryModel { Contiguous, Paged, Fibonacci, OSBacked };
 
-template <typename CellT, bool Dynamic, bool Term>
+template <typename CellT, bool Dynamic, bool Term, bool Sparse>
 int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
                 int eof, MemoryModel model);
 
@@ -42,7 +42,8 @@ static void test_initial_failure() {
     std::string code;
     std::ostringstream err;
     auto* old = std::cerr.rdbuf(err.rdbuf());
-    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
+    int ret =
+        executeImpl<uint8_t, true, false, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
     std::cerr.rdbuf(old);
     goof2::os_alloc = real_alloc;
     assert(ret == 0);
@@ -68,7 +69,8 @@ static void test_growth_failure() {
     std::string code = ">";
     std::ostringstream err;
     auto* old = std::cerr.rdbuf(err.rdbuf());
-    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
+    int ret =
+        executeImpl<uint8_t, true, false, false>(cells, ptr, code, true, 0, MemoryModel::OSBacked);
     std::cerr.rdbuf(old);
     goof2::os_alloc = real_alloc;
     assert(ret == 0);

--- a/tests/test_memory_models.cxx
+++ b/tests/test_memory_models.cxx
@@ -8,15 +8,16 @@
 
 enum class MemoryModel { Contiguous, Paged, Fibonacci, OSBacked };
 
-template <typename CellT, bool Dynamic, bool Term>
+template <typename CellT, bool Dynamic, bool Term, bool Sparse>
 int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
                 int eof, MemoryModel model);
 
-static void run_model(MemoryModel model, size_t expectedSize) {
+static void run_model(MemoryModel model, bool sparse, size_t expectedSize) {
     std::vector<uint8_t> cells(1, 0);
     size_t ptr = 0;
     std::string code = ">";
-    int ret = executeImpl<uint8_t, true, false>(cells, ptr, code, true, 0, model);
+    int ret = sparse ? executeImpl<uint8_t, true, false, true>(cells, ptr, code, true, 0, model)
+                     : executeImpl<uint8_t, true, false, false>(cells, ptr, code, true, 0, model);
     (void)ret;
     assert(ret == 0);
     assert(ptr == 1);
@@ -25,11 +26,17 @@ static void run_model(MemoryModel model, size_t expectedSize) {
 }
 
 int main() {
-    run_model(MemoryModel::Contiguous, 2);
-    run_model(MemoryModel::Paged, 2);
-    run_model(MemoryModel::Fibonacci, 2);
+    run_model(MemoryModel::Contiguous, false, 2);
+    run_model(MemoryModel::Paged, false, 2);
+    run_model(MemoryModel::Fibonacci, false, 2);
 #if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
-    run_model(MemoryModel::OSBacked, 2);
+    run_model(MemoryModel::OSBacked, false, 2);
+#endif
+    run_model(MemoryModel::Contiguous, true, 2);
+    run_model(MemoryModel::Paged, true, 2);
+    run_model(MemoryModel::Fibonacci, true, 2);
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
+    run_model(MemoryModel::OSBacked, true, 2);
 #endif
     return 0;
 }


### PR DESCRIPTION
## Summary
- Replace runtime sparse flag with a `Sparse` template parameter, removing branches in the VM
- Add pointer-span heuristic to choose between contiguous and sparse execution at runtime
- Update tests to instantiate sparse and contiguous execution paths explicitly

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a7cad0f188331876bfaf40475502e