### PR TITLE
Check current cell before scan loops

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -990,9 +990,16 @@ _MUL_CPY:
 _SCN_RGT: {
     const unsigned step = static_cast<unsigned>(insp->data);
     if constexpr (Sparse) {
+        if (sparseTape[sparseIndex] == 0) {
+            LOOP();
+        }
         do {
             sparseIndex += step;
         } while (sparseTape[sparseIndex] != 0);
+        LOOP();
+    }
+
+    if (*cell == 0) {
         LOOP();
     }
 
@@ -1048,6 +1055,9 @@ _SCN_RGT: {
 _SCN_LFT: {
     const unsigned step = static_cast<unsigned>(insp->data);
     if constexpr (Sparse) {
+        if (sparseTape[sparseIndex] == 0) {
+            LOOP();
+        }
         while (sparseIndex >= step && sparseTape[sparseIndex] != 0) {
             sparseIndex -= step;
         }
@@ -1063,6 +1073,10 @@ _SCN_LFT: {
         cellPtr = 0;
         std::cerr << "cell pointer moved before start" << std::endl;
         return -1;
+    }
+
+    if (*cell == 0) {
+        LOOP();
     }
 
     if (step == 1) {

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -135,6 +135,15 @@ static void test_scan_stride() {
         run<CellT>("[<<<<<<<<]", cells, ptr);
         assert(ptr == 0);
     }
+    {
+        std::vector<CellT> cells(2, 0);
+        cells[0] = 1;
+        size_t ptr = 1;
+        int ret;
+        run<CellT>("[<<]", cells, ptr, "", 0, true, &ret);
+        assert(ret == 0);
+        assert(ptr == 1);
+    }
 }
 
 template <typename CellT>


### PR DESCRIPTION
## Summary
- Fix SCN_RGT and SCN_LFT to skip scanning if the starting cell is already zero
- Add regression test ensuring scan loops with zero starting cell do not move the pointer

## Testing
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689a851d88d08331b503a87fa774008f