### PR TITLE
Handle misaligned strided scan loops

### DIFF
--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -136,6 +136,22 @@ static void test_scan_stride() {
         assert(ptr == 0);
     }
     {
+        std::vector<CellT> cells(6, 0);
+        cells[5] = 1;
+        cells[3] = 1;
+        size_t ptr = 5;
+        run<CellT>("[<<]", cells, ptr);
+        assert(ptr == 1);
+    }
+    {
+        std::vector<CellT> cells(6, 0);
+        cells[1] = 1;
+        cells[3] = 1;
+        size_t ptr = 1;
+        run<CellT>("[>>]", cells, ptr);
+        assert(ptr == 5);
+    }
+    {
         std::vector<CellT> cells(2, 0);
         cells[0] = 1;
         size_t ptr = 1;


### PR DESCRIPTION
## Summary
- ensure strided scan loops fall back to scalar logic when pointer is misaligned
- add tests covering misaligned left and right scan cases

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a887678548331ba59f0afd4480e7c