### PR TITLE
Ensure repl includes algorithm header directly

### DIFF
--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
 #ifdef GOOF2_ENABLE_REPL
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <ostream>


### PR DESCRIPTION
## Summary
- include `<algorithm>` in `repl.hxx` so std::max/min are available without relying on transitive includes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a900eb8c48331b3c3ce1d362b2b39