### PR TITLE
Add newline to file error messages

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -106,14 +106,14 @@ int main(int argc, char* argv[]) {
         if (!in.is_open()) {
             std::cout << Term::color_fg(Term::Color::Name::Red)
                       << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
-                      << " File could not be opened";
+                      << " File could not be opened" << std::endl;
             return 1;
         }
         std::string code((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
         if (!in && !in.eof()) {
             std::cout << Term::color_fg(Term::Color::Name::Red)
                       << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
-                      << " Error while reading file";
+                      << " Error while reading file" << std::endl;
             return 1;
         }
         switch (cfg.cellWidth) {


### PR DESCRIPTION
## Summary
- ensure file opening and reading error messages end with newlines

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j2`
- `ctest --test-dir build`
- `TERM=dumb ./build/goof2 -i nonexistent`
- `g++ /tmp/test_read_error.cpp -o /tmp/test_read_error && /tmp/test_read_error`


------
https://chatgpt.com/codex/tasks/task_e_689a903292108331920b98e01256e18b