### PR TITLE
Support loading code files in REPL

### DIFF
--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <fstream>
 #include <sstream>
 
 #include "cpp-terminal/color.hpp"
@@ -281,8 +282,29 @@ int runRepl(std::vector<CellT>& cells, size_t& cellPtr, ReplConfig& cfg) {
                 std::ostringstream oss;
                 dumpMemory<CellT>(cells, cellPtr, oss);
                 appendLines(log, oss.str());
+            } else if (input.rfind("load ", 0) == 0) {
+                std::string path = input.substr(5);
+                path.erase(0, path.find_first_not_of(" \t"));
+                if (path.empty()) {
+                    log.push_back("ERROR: missing file path");
+                } else {
+                    std::ifstream file(path);
+                    if (!file) {
+                        log.push_back("ERROR: failed to open file: " + path);
+                    } else {
+                        std::ostringstream buf;
+                        buf << file.rdbuf();
+                        std::string code = buf.str();
+                        std::ostringstream oss;
+                        std::streambuf* oldbuf = std::cout.rdbuf(oss.rdbuf());
+                        executeExcept<CellT>(cells, cellPtr, code, cfg.optimize, cfg.eof,
+                                             cfg.dynamicSize, true);
+                        std::cout.rdbuf(oldbuf);
+                        appendLines(log, oss.str());
+                    }
+                }
             } else if (input == "help") {
-                log.push_back("Commands: help, dump, clear, exit/quit");
+                log.push_back("Commands: help, dump, load <file>, clear, exit/quit");
             } else if (!input.empty()) {
                 std::ostringstream oss;
                 std::streambuf* oldbuf = std::cout.rdbuf(oss.rdbuf());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,17 @@ target_link_libraries(vm_memory_model_tests PRIVATE
 
 add_test(NAME vm_memory_model_tests COMMAND vm_memory_model_tests)
 
+add_executable(vm_load_file_tests
+    test_load.cxx
+)
+
+target_link_libraries(vm_load_file_tests PRIVATE
+    vm
+    Warnings
+)
+
+add_test(NAME vm_load_file_tests COMMAND vm_load_file_tests)
+
 add_executable(vm_execute_fuzz
     fuzz_execute.cxx
 )

--- a/tests/test_load.cxx
+++ b/tests/test_load.cxx
@@ -1,0 +1,56 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "vm.hxx"
+
+template <typename CellT>
+static std::string runFile(const std::string& path, std::vector<CellT>& cells, size_t& cellPtr,
+                           const std::string& input = "") {
+    std::ifstream file(path);
+    std::string code((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    std::istringstream in(input);
+    std::ostringstream out;
+    auto* cinbuf = std::cin.rdbuf(in.rdbuf());
+    auto* coutbuf = std::cout.rdbuf(out.rdbuf());
+    std::cin.clear();
+    goof2::execute<CellT>(cells, cellPtr, code, true, 0, true, false);
+    std::cin.rdbuf(cinbuf);
+    std::cout.rdbuf(coutbuf);
+    return out.str();
+}
+
+template <typename CellT>
+static void test_load_file() {
+    const char* fname = "test_program.bf";
+    {
+        std::ofstream f(fname);
+        f << ",.";
+    }
+    std::vector<CellT> cells(1, 0);
+    size_t ptr = 0;
+    std::string out = runFile<CellT>(fname, cells, ptr, "A");
+    assert(out == "A");
+    assert(cells[0] == static_cast<CellT>('A'));
+    std::remove(fname);
+}
+
+template <typename CellT>
+static void run_tests() {
+    test_load_file<CellT>();
+}
+
+int main() {
+    run_tests<uint8_t>();
+    run_tests<uint16_t>();
+    run_tests<uint32_t>();
+    run_tests<uint64_t>();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Extend REPL to handle `load <file>` command, executing file contents and capturing output
- Mention `load` in REPL help text
- Add unit test for executing Brainfuck code loaded from a file

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a910d46d0833181a75996dbaf4aa0