### PR TITLE
Handle invalid numeric arguments

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -62,11 +63,35 @@ CmdArgs parseArgs(int argc, char* argv[]) {
         } else if (arg == "-dts") {
             args.dynamicTape = true;
         } else if (arg == "-eof" && i + 1 < argc) {
-            args.eof = std::stoi(argv[++i]);
+            const char* val = argv[++i];
+            char* end = nullptr;
+            long parsed = std::strtol(val, &end, 10);
+            if (end == val || *end != '\0') {
+                std::cerr << "Invalid EOF mode: " << val << std::endl;
+                args.help = true;
+            } else {
+                args.eof = static_cast<int>(parsed);
+            }
         } else if (arg == "-ts" && i + 1 < argc) {
-            args.tapeSize = static_cast<std::size_t>(std::stoull(argv[++i]));
+            const char* val = argv[++i];
+            char* end = nullptr;
+            unsigned long long parsed = std::strtoull(val, &end, 10);
+            if (val[0] == '-' || end == val || *end != '\0' || parsed == 0) {
+                std::cerr << "Tape size must be a positive integer: " << val << std::endl;
+                args.help = true;
+            } else {
+                args.tapeSize = static_cast<std::size_t>(parsed);
+            }
         } else if (arg == "-cw" && i + 1 < argc) {
-            args.cellWidth = std::stoi(argv[++i]);
+            const char* val = argv[++i];
+            char* end = nullptr;
+            long parsed = std::strtol(val, &end, 10);
+            if (end == val || *end != '\0' || parsed <= 0) {
+                std::cerr << "Cell width must be a positive integer: " << val << std::endl;
+                args.help = true;
+            } else {
+                args.cellWidth = static_cast<int>(parsed);
+            }
         }
     }
     return args;


### PR DESCRIPTION
## Summary
- Replace try/catch parsing with `std::strtol`/`std::strtoull`
- Reject non-positive tape size or cell width and show help

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689a9018a8a083318efbd91f09ac37be