### PR TITLE
Silence warnings that broke -Werror builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ FetchContent_Declare(simde
 
 if(GOOF2_ENABLE_REPL)
     FetchContent_MakeAvailable(cpp-terminal)
+    # cpp-terminal triggers some warnings that can become build errors
+    # when projects compile with -Werror.  Silence the specific warnings
+    # about ignored return values and unused variables so that enabling
+    # -Werror does not break the build.
+    target_compile_options(cpp-terminal PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wno-unused-result -Wno-unused-variable -Wno-unused-but-set-variable>
+    )
 endif()
 FetchContent_GetProperties(simde)
 if(NOT simde_POPULATED)
@@ -86,6 +93,9 @@ target_include_directories(vm
         ${SIMDE_INCLUDE_DIR}
 )
 target_link_libraries(vm PRIVATE Warnings)
+target_compile_options(vm PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-psabi>
+)
 
 set(EXEC_SOURCES
     main.cxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ target_include_directories(vm
     PRIVATE
         ${SIMDE_INCLUDE_DIR}
 )
-target_link_libraries(vm PRIVATE Warnings)
+target_link_libraries(vm PRIVATE $<BUILD_INTERFACE:Warnings>)
 target_compile_options(vm PRIVATE
     $<$<CXX_COMPILER_ID:GNU>:-Wno-psabi>
 )
@@ -115,7 +115,7 @@ add_executable(goof2
 
 target_link_libraries(goof2 PRIVATE
     vm
-    Warnings
+    $<BUILD_INTERFACE:Warnings>
 )
 if(GOOF2_ENABLE_REPL)
     target_link_libraries(goof2 PRIVATE cpp-terminal::cpp-terminal)


### PR DESCRIPTION
## Summary
- suppress cpp-terminal warnings about unused variables and results
- disable psabi warning for vm to allow builds with -Werror

## Testing
- `cmake -S . -B build-werror -DCMAKE_CXX_FLAGS='-Werror'`
- `cmake --build build-werror`
- `ctest --test-dir build-werror`


------
https://chatgpt.com/codex/tasks/task_e_689a91d07dd08331a146bb4f943bb681