### PR TITLE
Add inline Brainfuck evaluation via -e option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ An HTML report will be generated in `build/coverage`. Open
 
 ## Usage
 
+The VM can execute a Brainfuck program from a file using `-i <file>` or directly from
+an inline string with `-e <code>`. When `-e` is provided any `-i` option is ignored.
+Inline execution works with all other flags, e.g. optimization or tape settings.
+
+```sh
+printf 'A' | ./goof2 -e ',.'
+./goof2 -e '+++' -nopt
+```
+
 The VM supports selectable cell widths. Use the `--cw` option to choose 8-, 16- or 32-bit
 cells at startup:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,3 +39,17 @@ target_link_libraries(vm_execute_fuzz PRIVATE
     vm
     Warnings
 )
+
+add_executable(vm_cli_eval_tests
+    test_cli_eval.cxx
+)
+
+target_link_libraries(vm_cli_eval_tests PRIVATE
+    Warnings
+)
+
+target_compile_definitions(vm_cli_eval_tests PRIVATE
+    GOOF2_EXE_PATH="$<TARGET_FILE:goof2>"
+)
+
+add_test(NAME vm_cli_eval_tests COMMAND vm_cli_eval_tests)

--- a/tests/test_cli_eval.cxx
+++ b/tests/test_cli_eval.cxx
@@ -1,0 +1,35 @@
+#include <array>
+#include <cassert>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
+static std::string run_inline(const std::string& code, const std::string& extra = "") {
+    std::string cmd = std::string("'") + GOOF2_EXE_PATH + "' -e '" + code + "'" +
+                      (extra.empty() ? "" : " " + extra) + " 2>&1";
+    std::array<char, 256> buf{};
+    std::string out;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    assert(pipe);
+    while (fgets(buf.data(), buf.size(), pipe.get())) out += buf.data();
+    int rc = pclose(pipe.release());
+    assert(rc == 0);
+    (void)rc;
+    return out;
+}
+
+int main() {
+    const std::string helloA = "++++++++[>++++++++<-]>+.";  // prints 'A'
+    std::string out = run_inline(helloA);
+    assert(out == "A");
+    out = run_inline(helloA, "-nopt");
+    assert(out == "A");
+    out = run_inline(helloA, "-i nofile.bf");
+    assert(out == "A");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `-e <code>` flag to run inline Brainfuck and ignore `-i`
- document and test inline evaluation alongside other CLI flags

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689a90fd63408331baff2e48df3ad237