### PR TITLE
Add profiling flag and VM instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ cells at startup:
 ./goof2 --cw 16 program.bf
 ```
 
+Add `--profile` to measure execution time and instruction count:
+
+```sh
+./goof2 --profile program.bf
+```
+
 Select a memory allocation strategy with `-mm <contiguous|fibonacci|paged|os>`. If omitted,
 the VM chooses a model heuristically. In the interactive REPL, press `F8` to cycle through
 the available models.

--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -28,6 +28,11 @@ extern void (*os_free)(void*, size_t);
 #endif
 
 enum class MemoryModel { Auto, Contiguous, Fibonacci, Paged, OSBacked };
+
+struct ProfileInfo {
+    std::uint64_t instructions = 0;
+    double seconds = 0.0;
+};
 /// @brief Only function you should use in your code. For now, it always prints to stdout.
 /// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
 /// @param cells Vector of cells of type CellT.
@@ -53,5 +58,5 @@ template <typename CellT>
 int execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
             bool optimize = GOOF2_OPTIMIZE, int eof = GOOF2_DEFAULT_EOF_BEHAVIOUR,
             bool dynamicSize = GOOF2_DYNAMIC_CELLS_SIZE, bool term = GOOF2_DEFAULT_SAVE_STATE,
-            MemoryModel model = MemoryModel::Auto);
+            MemoryModel model = MemoryModel::Auto, ProfileInfo* profile = nullptr);
 }  // namespace goof2

--- a/main.cxx
+++ b/main.cxx
@@ -44,6 +44,7 @@ struct CmdArgs {
     bool help = false;
     bool optimize = true;
     bool dynamicTape = false;
+    bool profile = false;
     int eof = 0;
     std::size_t tapeSize = 30000;
     int cellWidth = 8;
@@ -94,6 +95,8 @@ CmdArgs parseArgs(int argc, char* argv[]) {
             } else {
                 args.cellWidth = static_cast<int>(parsed);
             }
+        } else if (arg == "--profile") {
+            args.profile = true;
         } else if (arg == "-mm" && i + 1 < argc) {
             std::string mm = argv[++i];
             std::transform(mm.begin(), mm.end(), mm.begin(),
@@ -127,6 +130,7 @@ int main(int argc, char* argv[]) {
     const bool help = opts.help;
     ReplConfig cfg{opts.optimize, opts.dynamicTape, opts.eof,
                    opts.tapeSize, opts.cellWidth,   opts.model};
+    const bool profile = opts.profile;
     if (cfg.tapeSize == 0) {
         std::cout << Term::color_fg(Term::Color::Name::Red)
                   << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
@@ -160,32 +164,34 @@ int main(int argc, char* argv[]) {
                       << " Error while reading file" << std::endl;
             return 1;
         }
+        goof2::ProfileInfo profileInfo;
+        goof2::ProfileInfo* profPtr = profile ? &profileInfo : nullptr;
         switch (cfg.cellWidth) {
             case 8: {
                 std::vector<uint8_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint8_t>(cells, cellPtr, code, cfg.optimize, cfg.eof, cfg.dynamicSize,
-                                       cfg.model);
+                                       cfg.model, profPtr);
                 if (dumpMemoryFlag) dumpMemory<uint8_t>(cells, cellPtr);
                 break;
             }
             case 16: {
                 std::vector<uint16_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint16_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize, cfg.model);
+                                        cfg.dynamicSize, cfg.model, profPtr);
                 if (dumpMemoryFlag) dumpMemory<uint16_t>(cells, cellPtr);
                 break;
             }
             case 32: {
                 std::vector<uint32_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint32_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize, cfg.model);
+                                        cfg.dynamicSize, cfg.model, profPtr);
                 if (dumpMemoryFlag) dumpMemory<uint32_t>(cells, cellPtr);
                 break;
             }
             case 64: {
                 std::vector<uint64_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint64_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize, cfg.model);
+                                        cfg.dynamicSize, cfg.model, profPtr);
                 if (dumpMemoryFlag) dumpMemory<uint64_t>(cells, cellPtr);
                 break;
             }
@@ -194,6 +200,10 @@ int main(int argc, char* argv[]) {
                           << "ERROR:" << Term::color_fg(Term::Color::Name::Default)
                           << " Unsupported cell width; use 8,16,32,64" << std::endl;
                 return 1;
+        }
+        if (profile) {
+            std::cout << "Instructions executed: " << profileInfo.instructions << std::endl;
+            std::cout << "Elapsed time: " << profileInfo.seconds << "s" << std::endl;
         }
         return 0;
     }
@@ -256,8 +266,10 @@ void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr) {
 
 template <typename CellT>
 void executeExcept(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
-                   int eof, bool dynamicSize, goof2::MemoryModel model) {
-    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, false, model);
+                   int eof, bool dynamicSize, goof2::MemoryModel model,
+                   goof2::ProfileInfo* profile) {
+    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, false, model,
+                                    profile);
     switch (ret) {
         case 1:
             std::cerr << "ERROR: Unmatched close bracket";
@@ -281,6 +293,7 @@ int main(int argc, char* argv[]) {
     std::size_t tapeSize = opts.tapeSize;
     int cellWidth = opts.cellWidth;
     goof2::MemoryModel model = opts.model;
+    const bool profile = opts.profile;
     if (tapeSize == 0) {
         std::cout << "ERROR: Tape size must be positive; using default 30000" << std::endl;
         tapeSize = 30000;
@@ -309,34 +322,44 @@ int main(int argc, char* argv[]) {
         std::cerr << "ERROR: Error while reading file";
         return 1;
     }
+    goof2::ProfileInfo prof;
+    goof2::ProfileInfo* profPtr = profile ? &prof : nullptr;
     switch (cellWidth) {
         case 8: {
             std::vector<uint8_t> cells(tapeSize, 0);
-            executeExcept<uint8_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model);
+            executeExcept<uint8_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model,
+                                   profPtr);
             if (dumpMemoryFlag) dumpMemory<uint8_t>(cells, cellPtr);
             break;
         }
         case 16: {
             std::vector<uint16_t> cells(tapeSize, 0);
-            executeExcept<uint16_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model);
+            executeExcept<uint16_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model,
+                                    profPtr);
             if (dumpMemoryFlag) dumpMemory<uint16_t>(cells, cellPtr);
             break;
         }
         case 32: {
             std::vector<uint32_t> cells(tapeSize, 0);
-            executeExcept<uint32_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model);
+            executeExcept<uint32_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model,
+                                    profPtr);
             if (dumpMemoryFlag) dumpMemory<uint32_t>(cells, cellPtr);
             break;
         }
         case 64: {
             std::vector<uint64_t> cells(tapeSize, 0);
-            executeExcept<uint64_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model);
+            executeExcept<uint64_t>(cells, cellPtr, code, optimize, eof, dynamicSize, model,
+                                    profPtr);
             if (dumpMemoryFlag) dumpMemory<uint64_t>(cells, cellPtr);
             break;
         }
         default:
             std::cerr << "ERROR: Unsupported cell width; use 8,16,32,64" << std::endl;
             return 1;
+    }
+    if (profile) {
+        std::cout << "Instructions executed: " << prof.instructions << std::endl;
+        std::cout << "Elapsed time: " << prof.seconds << "s" << std::endl;
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `--profile` flag to count instructions and timing
- instrument VM to record instruction count and elapsed time
- document `--profile` flag in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689b00e9cb248331a27887dcbfeae409