### PR TITLE
Improve -h output and remove REPL dump command

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -121,6 +121,21 @@ CmdArgs parseArgs(int argc, char* argv[]) {
     }
     return args;
 }
+void printHelp(const char* prog) {
+    std::cout << "Usage: " << prog << " [options]\n"
+              << "Options:\n"
+              << "  -e <code>        Execute Brainfuck code directly\n"
+              << "  -i <file>        Execute code from file\n"
+              << "  -dm              Dump memory after program\n"
+              << "  -nopt            Disable optimizations\n"
+              << "  -dts             Enable dynamic tape resizing\n"
+              << "  -eof <value>     Set EOF return value\n"
+              << "  -ts <size>       Tape size in cells (default 30000)\n"
+              << "  -cw <width>      Cell width in bits (8,16,32,64)\n"
+              << "  --profile        Print execution profile\n"
+              << "  -mm <model>      Memory model (auto, contiguous, fibonacci, paged, os)\n"
+              << "  -h               Show this help message" << std::endl;
+}
 }  // namespace
 
 #ifdef GOOF2_ENABLE_REPL
@@ -150,7 +165,7 @@ int main(int argc, char* argv[]) {
                   << std::endl;
     }
     if (help) {
-        std::cout << "Usage: " << argv[0] << " [options]" << std::endl;
+        printHelp(argv[0]);
         return 0;
     }
     if (!evalCode.empty()) {
@@ -159,29 +174,29 @@ int main(int argc, char* argv[]) {
         switch (cfg.cellWidth) {
             case 8: {
                 std::vector<uint8_t> cells(cfg.tapeSize, 0);
-                executeExcept<uint8_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                       cfg.dynamicSize);
+                executeExcept<uint8_t>(cells, cellPtr, code, cfg.optimize, cfg.eof, cfg.dynamicSize,
+                                       cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint8_t>(cells, cellPtr);
                 break;
             }
             case 16: {
                 std::vector<uint16_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint16_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint16_t>(cells, cellPtr);
                 break;
             }
             case 32: {
                 std::vector<uint32_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint32_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint32_t>(cells, cellPtr);
                 break;
             }
             case 64: {
                 std::vector<uint64_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint64_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint64_t>(cells, cellPtr);
                 break;
             }
@@ -350,7 +365,7 @@ int main(int argc, char* argv[]) {
                   << " MiB may exceed system memory" << std::endl;
     }
     if (help) {
-        std::cout << "Usage: " << argv[0] << " [options]" << std::endl;
+        printHelp(argv[0]);
         return 0;
     }
     if (filename.empty() && evalCode.empty()) {

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -317,10 +317,6 @@ int runRepl(std::vector<CellT>& cells, size_t& cellPtr, ReplConfig& cfg) {
                 on = false;
             } else if (input == "clear") {
                 resetContext();
-            } else if (input == "dump") {
-                std::ostringstream oss;
-                dumpMemory<CellT>(cells, cellPtr, oss);
-                appendLines(log, oss.str());
             } else if (input.rfind("load ", 0) == 0) {
                 std::string path = input.substr(5);
                 path.erase(0, path.find_first_not_of(" \t"));
@@ -344,7 +340,7 @@ int runRepl(std::vector<CellT>& cells, size_t& cellPtr, ReplConfig& cfg) {
                     }
                 }
             } else if (input == "help") {
-                log.push_back("Commands: help, dump, load <file>, clear, exit/quit");
+                log.push_back("Commands: help, load <file>, clear, exit/quit");
             } else if (!input.empty()) {
                 std::ostringstream oss;
                 std::streambuf* oldbuf = std::cout.rdbuf(oss.rdbuf());


### PR DESCRIPTION
## Summary
- show detailed usage information when running with `-h`
- drop `dump` command from the REPL and update help text accordingly

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689b0489028c8331a6e3ce211d7ae651