### PR TITLE
Fix build by updating executeExcept signature

### DIFF
--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -61,8 +61,9 @@ inline void dumpMemory(const std::vector<CellT>& cells, size_t cellPtr,
 template <typename CellT>
 inline void executeExcept(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
                           bool optimize, int eof, bool dynamicSize, goof2::MemoryModel model,
-                          bool term = false) {
-    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, term, model);
+                          goof2::ProfileInfo* profile = nullptr, bool term = false) {
+    int ret = goof2::execute<CellT>(cells, cellPtr, code, optimize, eof, dynamicSize, term, model,
+                                    profile);
     switch (ret) {
         case 1:
             std::cout << Term::color_fg(Term::Color::Name::Red)

--- a/main.cxx
+++ b/main.cxx
@@ -159,29 +159,29 @@ int main(int argc, char* argv[]) {
         switch (cfg.cellWidth) {
             case 8: {
                 std::vector<uint8_t> cells(cfg.tapeSize, 0);
-                executeExcept<uint8_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                       cfg.dynamicSize);
+                executeExcept<uint8_t>(cells, cellPtr, code, cfg.optimize, cfg.eof, cfg.dynamicSize,
+                                       cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint8_t>(cells, cellPtr);
                 break;
             }
             case 16: {
                 std::vector<uint16_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint16_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint16_t>(cells, cellPtr);
                 break;
             }
             case 32: {
                 std::vector<uint32_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint32_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint32_t>(cells, cellPtr);
                 break;
             }
             case 64: {
                 std::vector<uint64_t> cells(cfg.tapeSize, 0);
                 executeExcept<uint64_t>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                        cfg.dynamicSize);
+                                        cfg.dynamicSize, cfg.model);
                 if (dumpMemoryFlag) dumpMemory<uint64_t>(cells, cellPtr);
                 break;
             }

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -337,7 +337,7 @@ int runRepl(std::vector<CellT>& cells, size_t& cellPtr, ReplConfig& cfg) {
                         std::ostringstream oss;
                         std::streambuf* oldbuf = std::cout.rdbuf(oss.rdbuf());
                         executeExcept<CellT>(cells, cellPtr, code, cfg.optimize, cfg.eof,
-                                             cfg.dynamicSize, cfg.model, true);
+                                             cfg.dynamicSize, cfg.model, nullptr, true);
 
                         std::cout.rdbuf(oldbuf);
                         appendLines(log, oss.str());
@@ -349,7 +349,7 @@ int runRepl(std::vector<CellT>& cells, size_t& cellPtr, ReplConfig& cfg) {
                 std::ostringstream oss;
                 std::streambuf* oldbuf = std::cout.rdbuf(oss.rdbuf());
                 executeExcept<CellT>(cells, cellPtr, input, cfg.optimize, cfg.eof, cfg.dynamicSize,
-                                     cfg.model, true);
+                                     cfg.model, nullptr, true);
                 std::cout.rdbuf(oldbuf);
                 appendLines(log, oss.str());
             }


### PR DESCRIPTION
## Summary
- Extend `executeExcept` to accept memory model and optional profiling pointer
- Pass memory model to inline execution paths and adjust REPL calls

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689b06abb374833187b3063367f7337c