### PR TITLE
Enable Dependabot submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- enable beta ecosystems for Dependabot so git submodule updates run

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689b1cc770b88331a2b4ed7173f5ec1b