### PR TITLE
Scale parallel test with hardware concurrency

### DIFF
--- a/tests/test_parallel.cxx
+++ b/tests/test_parallel.cxx
@@ -1,13 +1,16 @@
 #include <cassert>
 #include <chrono>
 #include <future>
+#include <thread>
 #include <vector>
 
 #include "parallel.hxx"
 #include "vm.hxx"
 
 static void testPerformance() {
-    const std::size_t n = 1u << 20;  // large enough to benefit from parallelism
+    unsigned int threads = std::thread::hardware_concurrency();
+    const std::size_t n = (1u << 17) * (threads ? threads : 1);
+    // Scale work with available cores so the loop still benefits from parallelism
     std::vector<int> data(n);
     auto startSeq = std::chrono::high_resolution_clock::now();
     for (std::size_t i = 0; i < n; ++i) data[i] = 1;
@@ -15,7 +18,9 @@ static void testPerformance() {
     auto startPar = std::chrono::high_resolution_clock::now();
     goof2::parallelFor(0, n, [&](std::size_t i) { data[i] = 2; });
     auto parDur = std::chrono::high_resolution_clock::now() - startPar;
-    assert(parDur <= seqDur);
+    if (threads > 1) {
+        assert(parDur <= seqDur);
+    }
     for (int v : data) {
         assert(v == 2);
         (void)v;


### PR DESCRIPTION
## Summary
- derive parallel test workload from `std::thread::hardware_concurrency` to adapt to core count
- skip timing assertion on single-core systems

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R parallel -V`


------
https://chatgpt.com/codex/tasks/task_e_689b3508139483319782b2323eeecc0c