### PR TITLE
Add model-guided fuzzing harness

### DIFF
--- a/tests/fuzz_execute.cxx
+++ b/tests/fuzz_execute.cxx
@@ -2,16 +2,72 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <fstream>
 #include <iostream>
 #include <random>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "vm.hxx"
 
-static std::string random_program(std::mt19937 &gen) {
+#ifdef USE_MODEL_FUZZ
+struct Transition {
+    char nextOp;
+    double cumulative;
+};
+using TransitionVec = std::vector<Transition>;
+using BigramModel = std::unordered_map<char, TransitionVec>;
+
+static BigramModel loadModel(const std::string& path) {
+    BigramModel model;
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream ss(line);
+        std::string fromStr, toStr, probStr;
+        if (!std::getline(ss, fromStr, ',')) continue;
+        if (!std::getline(ss, toStr, ',')) continue;
+        if (!std::getline(ss, probStr)) continue;
+        double prob = std::stod(probStr);
+        model[fromStr[0]].push_back({toStr[0], prob});
+    }
+    for (auto& kv : model) {
+        double acc = 0.0;
+        for (auto& t : kv.second) {
+            acc += t.cumulative;
+            t.cumulative = acc;
+        }
+    }
+    return model;
+}
+
+static std::string modelProgram(BigramModel& model, std::mt19937& gen) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    std::string program;
+    char prev = '^';
+    for (int i = 0; i < 16; ++i) {
+        auto it = model.find(prev);
+        if (it == model.end() || it->second.empty()) break;
+        double r = dist(gen);
+        char next = '^';
+        for (const auto& t : it->second) {
+            if (r <= t.cumulative) {
+                next = t.nextOp;
+                break;
+            }
+        }
+        if (next == '^') break;
+        program += next;
+        prev = next;
+    }
+    return program;
+}
+#else
+static std::string randomProgram(std::mt19937& gen) {
     static const char ops[] = "+-<>.,";
     std::uniform_int_distribution<int> lenDist(0, 16);
     std::uniform_int_distribution<int> opDist(0, sizeof(ops) - 2);
@@ -37,8 +93,9 @@ static std::string random_program(std::mt19937 &gen) {
     }
     return program;
 }
+#endif
 
-static std::string random_input(std::mt19937 &gen) {
+static std::string randomInput(std::mt19937& gen) {
     std::uniform_int_distribution<int> lenDist(0, 8);
     std::uniform_int_distribution<int> byteDist(0, 255);
     int len = lenDist(gen);
@@ -51,33 +108,49 @@ static std::string random_input(std::mt19937 &gen) {
 }
 
 int main() {
-    std::mt19937 gen(std::random_device{}());
+    std::mt19937 gen(123456u);
+#ifdef USE_MODEL_FUZZ
+    BigramModel model = loadModel("model.txt");
+#endif
     for (int i = 0; i < 100; ++i) {
-        std::string code = random_program(gen);
-        std::string input = random_input(gen);
+#ifdef USE_MODEL_FUZZ
+        std::string code = modelProgram(model, gen);
+#else
+        std::string code = randomProgram(gen);
+#endif
+        std::string input = randomInput(gen);
         std::vector<uint8_t> cells(32, 0);
         size_t ptr = 0;
         std::istringstream in(input);
         std::ostringstream out;
-        auto *cinbuf = std::cin.rdbuf(in.rdbuf());
-        auto *coutbuf = std::cout.rdbuf(out.rdbuf());
+        auto* cinBuf = std::cin.rdbuf(in.rdbuf());
+        auto* coutBuf = std::cout.rdbuf(out.rdbuf());
         std::cin.clear();
         std::atomic_bool done{false};
-        std::thread watchdog([&done]() {
+        std::thread watchdogThread([&done]() {
             for (int i = 0; i < 100; ++i) {
                 if (done.load()) return;
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
             std::terminate();
         });
+        goof2::ProfileInfo profile;
         try {
-            goof2::execute<uint8_t>(cells, ptr, code, true, 0, true, false);
+            goof2::execute<uint8_t>(cells, ptr, code, true, 0, true, false,
+                                    goof2::MemoryModel::Auto, &profile);
         } catch (...) {
         }
         done = true;
-        watchdog.join();
-        std::cin.rdbuf(cinbuf);
-        std::cout.rdbuf(coutbuf);
+        watchdogThread.join();
+        std::cin.rdbuf(cinBuf);
+        std::cout.rdbuf(coutBuf);
+        std::ofstream covFile("coverage.jsonl", std::ios::app);
+        covFile << "{\"program\":\"" << code << "\",\"coverage\":[";
+        for (size_t j = 0; j < profile.loopCounts.size(); ++j) {
+            if (j) covFile << ',';
+            covFile << profile.loopCounts[j];
+        }
+        covFile << "]}\n";
     }
     return 0;
 }

--- a/tools/ml_fuzz/trainModel.py
+++ b/tools/ml_fuzz/trainModel.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Train a simple bigram sequence model for Brainfuck programs based on
+coverage data produced by the fuzz harness. Each input line in the
+coverage file should be a JSON object of the form::
+
+    {"program": "++-", "coverage": [1,0,2]}
+
+Programs that leave more paths uncovered are given higher weight when
+building the model. The resulting transition probabilities are written to
+``model.txt`` with one comma-separated transition per line:
+
+    prev,next,probability
+
+where ``prev`` is either ``^`` for the start state or a Brainfuck
+character and ``next`` is one of ``+-<>.,[]``.
+"""
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def trainModel(coveragePath: Path, outputPath: Path) -> None:
+    tokens = ['+', '-', '<', '>', '.', ',', '[', ']']
+    startToken = '^'
+    transitions = defaultdict(lambda: defaultdict(float))
+    if coveragePath.exists():
+        with coveragePath.open() as inFile:
+            for line in inFile:
+                data = json.loads(line)
+                programStr = data.get('program', '')
+                coverageVec = data.get('coverage', [])
+                weight = coverageVec.count(0) + 1
+                prevToken = startToken
+                for ch in programStr:
+                    if ch in tokens:
+                        transitions[prevToken][ch] += weight
+                        prevToken = ch
+                transitions[prevToken][startToken] += weight
+    epsilon = 1e-3
+    for frmToken in tokens + [startToken]:
+        for toToken in tokens:
+            transitions[frmToken][toToken] += epsilon
+    with outputPath.open('w') as outFile:
+        for frmToken in [startToken] + tokens:
+            total = sum(transitions[frmToken][toToken] for toToken in tokens)
+            for toToken in tokens:
+                prob = transitions[frmToken][toToken] / total if total else 1.0 / len(tokens)
+                outFile.write(f"{frmToken},{toToken},{prob}\n")
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Train bigram model for Brainfuck fuzzing')
+    parser.add_argument('coverage', type=Path, help='Path to coverage JSONL file')
+    parser.add_argument('-o', '--output', type=Path, default=Path('model.txt'),
+                        help='Output model file')
+    args = parser.parse_args()
+    trainModel(args.coverage, args.output)


### PR DESCRIPTION
## Summary
- add deterministic model-aware fuzz harness with optional generator flag and coverage logging
- introduce training script to build bigram model from coverage data

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689b39f08f848331bfbe2655493b7a25