### PR TITLE
Repeat ML optimization until stable

### DIFF
--- a/src/ml_opt.cxx
+++ b/src/ml_opt.cxx
@@ -30,8 +30,16 @@ static std::vector<std::pair<std::regex, std::string>> loadModel() {
 void applyMlOptimizer(std::string& code) {
     if (!mlOptimizerEnabled) return;
     static const auto rules = loadModel();
-    for (const auto& [pattern, replacement] : rules) {
-        code = std::regex_replace(code, pattern, replacement);
-    }
+    bool replaced;
+    do {
+        replaced = false;
+        for (const auto& [pattern, replacement] : rules) {
+            std::string newCode = std::regex_replace(code, pattern, replacement);
+            if (newCode != code) {
+                replaced = true;
+                code = std::move(newCode);
+            }
+        }
+    } while (replaced);
 }
 }  // namespace goof2


### PR DESCRIPTION
## Summary
- Iterate ML optimization rules until no further replacements occur
- Track per-pass regex changes and stop when code stabilizes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689b3e8b4ab08331a730a0ac4e820680