### PR TITLE
Handle malformed ML model rules

### DIFF
--- a/src/ml_opt.cxx
+++ b/src/ml_opt.cxx
@@ -7,6 +7,7 @@
 #include "ml_opt.hxx"
 
 #include <fstream>
+#include <iostream>
 #include <regex>
 #include <string>
 #include <vector>
@@ -17,12 +18,25 @@ bool mlOptimizerEnabled = false;
 static std::vector<std::pair<std::regex, std::string>> loadModel() {
     std::vector<std::pair<std::regex, std::string>> rules;
     std::ifstream in("assets/ml_model.txt");
+    if (!in) {
+        std::cerr << "warning: could not open ML model file assets/ml_model.txt" << std::endl;
+        return rules;
+    }
     std::string line;
+    size_t lineNo = 0;
     while (std::getline(in, line)) {
+        ++lineNo;
         if (line.empty()) continue;
         auto tab = line.find('\t');
-        if (tab == std::string::npos) continue;
+        if (tab == std::string::npos) {
+            std::cerr << "warning: skipping malformed rule at line " << lineNo
+                      << ": missing tab delimiter" << std::endl;
+            continue;
+        }
         rules.emplace_back(std::regex(line.substr(0, tab)), line.substr(tab + 1));
+    }
+    if (rules.empty()) {
+        std::cerr << "warning: no ML optimization rules loaded" << std::endl;
     }
     return rules;
 }


### PR DESCRIPTION
## Summary
- warn when ML model file cannot be opened
- log and skip malformed model rules without tab delimiters
- report when no ML optimization rules are loaded

## Testing
- `cmake -S . -B build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689b3f086f7483319558ac5e7622be27