### PR TITLE
Add ML benchmarking mode and replacement logging

### DIFF
--- a/include/ml_opt.hxx
+++ b/include/ml_opt.hxx
@@ -5,11 +5,14 @@
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
+#include <cstddef>
 #include <string>
 
 namespace goof2 {
 // Global toggle enabled via the --ml-opt command-line flag
 extern bool mlOptimizerEnabled;
+// Number of replacements made by the ML optimizer
+extern std::size_t mlOptimizerReplacements;
 // Apply model-based rewrites to the provided Brainfuck code
 void applyMlOptimizer(std::string& code);
 }  // namespace goof2

--- a/src/ml_opt.cxx
+++ b/src/ml_opt.cxx
@@ -13,6 +13,7 @@
 
 namespace goof2 {
 bool mlOptimizerEnabled = false;
+std::size_t mlOptimizerReplacements = 0;
 
 static std::vector<std::pair<std::regex, std::string>> loadModel() {
     std::vector<std::pair<std::regex, std::string>> rules;
@@ -29,8 +30,11 @@ static std::vector<std::pair<std::regex, std::string>> loadModel() {
 
 void applyMlOptimizer(std::string& code) {
     if (!mlOptimizerEnabled) return;
+    mlOptimizerReplacements = 0;
     static const auto rules = loadModel();
     for (const auto& [pattern, replacement] : rules) {
+        mlOptimizerReplacements += std::distance(
+            std::sregex_iterator(code.begin(), code.end(), pattern), std::sregex_iterator());
         code = std::regex_replace(code, pattern, replacement);
     }
 }


### PR DESCRIPTION
## Summary
- add `--ml-benchmark` option to run code twice and measure ML optimizer speed impact
- expose and track ML optimizer replacement counts

## Testing
- `cmake -S . -B build`
- `cmake --build build --target goof2`
- `./build/goof2 --ml-benchmark -i empty.bf -ts 10` *(terminated after no output)*

------
https://chatgpt.com/codex/tasks/task_e_689b3ea2730c8331985c374749de17fa