### PR TITLE
Handle invalid regex rules

### DIFF
--- a/assets/ml_model.txt
+++ b/assets/ml_model.txt
@@ -1,4 +1,4 @@
 # Auto-generated model
-+-	+
--+	-
+\+-	+
+-\+	-
 ><	>

--- a/src/ml_opt.cxx
+++ b/src/ml_opt.cxx
@@ -33,7 +33,12 @@ static std::vector<std::pair<std::regex, std::string>> loadModel() {
                       << ": missing tab delimiter" << std::endl;
             continue;
         }
-        rules.emplace_back(std::regex(line.substr(0, tab)), line.substr(tab + 1));
+        try {
+            rules.emplace_back(std::regex(line.substr(0, tab)), line.substr(tab + 1));
+        } catch (const std::regex_error& e) {
+            std::cerr << "warning: skipping invalid regex at line " << lineNo << ": " << e.what()
+                      << std::endl;
+        }
     }
     if (rules.empty()) {
         std::cerr << "warning: no ML optimization rules loaded" << std::endl;


### PR DESCRIPTION
## Summary
- escape special characters in ML model patterns to avoid regex parse errors
- skip invalid ML optimizer rules rather than aborting

## Testing
- `cmake --build build`
- `ctest --test-dir build` *(failed: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689c72d397fc8331b50137fd0abd3216