### PR TITLE
Embed ML optimizer model at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,18 @@ ProcessorCount(LTO_PARALLEL_JOBS)
 if(NOT LTO_PARALLEL_JOBS OR LTO_PARALLEL_JOBS EQUAL 0)
     set(LTO_PARALLEL_JOBS 1)
 endif()
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(ML_MODEL_TXT ${CMAKE_CURRENT_SOURCE_DIR}/assets/ml_model.txt)
+set(ML_MODEL_HEADER ${CMAKE_BINARY_DIR}/generated/mlModel.hxx)
+add_custom_command(
+    OUTPUT ${ML_MODEL_HEADER}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/generated
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/generateMlModelHeader.py ${ML_MODEL_TXT} ${ML_MODEL_HEADER}
+    DEPENDS ${ML_MODEL_TXT} ${CMAKE_CURRENT_SOURCE_DIR}/tools/generateMlModelHeader.py
+    COMMENT "Generating ML model header"
+)
+add_custom_target(generate_ml_model DEPENDS ${ML_MODEL_HEADER})
 
 # Link the C++ runtime statically on Windows to avoid missing procedure
 # entry point errors when running the prebuilt executable.
@@ -86,15 +98,18 @@ set(VM_SOURCES
     include/vm.hxx
     src/ml_opt.cxx
     include/ml_opt.hxx
+    ${ML_MODEL_HEADER}
 )
 
 add_library(vm ${VM_SOURCES})
+add_dependencies(vm generate_ml_model)
 target_include_directories(vm
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/goof2>
     PRIVATE
         ${SIMDE_INCLUDE_DIR}
+        ${CMAKE_BINARY_DIR}/generated
 )
 target_link_libraries(vm PRIVATE $<BUILD_INTERFACE:Warnings>)
 target_compile_options(vm PRIVATE

--- a/src/ml_opt.cxx
+++ b/src/ml_opt.cxx
@@ -6,49 +6,30 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "ml_opt.hxx"
 
-#include <fstream>
-#include <iostream>
 #include <regex>
 #include <string>
 #include <vector>
 
+#include "mlModel.hxx"
+
 namespace goof2 {
 bool mlOptimizerEnabled = true;
 
-static std::vector<std::pair<std::regex, std::string>> loadModel() {
-    std::vector<std::pair<std::regex, std::string>> rules;
-    std::ifstream in("assets/ml_model.txt");
-    if (!in) {
-        std::cerr << "warning: could not open ML model file assets/ml_model.txt" << std::endl;
-        return rules;
-    }
-    std::string line;
-    size_t lineNo = 0;
-    while (std::getline(in, line)) {
-        ++lineNo;
-        if (line.empty() || line[0] == '#' || line.rfind("//", 0) == 0) continue;
-        auto tab = line.find('\t');
-        if (tab == std::string::npos) {
-            std::cerr << "warning: skipping malformed rule at line " << lineNo
-                      << ": missing tab delimiter" << std::endl;
-            continue;
+static const std::vector<std::pair<std::regex, std::string>>& modelRules() {
+    static const auto rules = [] {
+        std::vector<std::pair<std::regex, std::string>> out;
+        out.reserve(mlModelCount);
+        for (size_t i = 0; i < mlModelCount; ++i) {
+            out.emplace_back(std::regex(mlModel[i].pattern), mlModel[i].replacement);
         }
-        try {
-            rules.emplace_back(std::regex(line.substr(0, tab)), line.substr(tab + 1));
-        } catch (const std::regex_error& e) {
-            std::cerr << "warning: skipping invalid regex at line " << lineNo << ": " << e.what()
-                      << std::endl;
-        }
-    }
-    if (rules.empty()) {
-        std::cerr << "warning: no ML optimization rules loaded" << std::endl;
-    }
+        return out;
+    }();
     return rules;
 }
 
 void applyMlOptimizer(std::string& code) {
     if (!mlOptimizerEnabled) return;
-    static const auto rules = loadModel();
+    static const auto& rules = modelRules();
     bool replaced;
     do {
         replaced = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,3 +104,15 @@ target_link_libraries(vm_model_selection_tests PRIVATE
 
 add_test(NAME vm_model_selection_tests COMMAND vm_model_selection_tests)
 set_tests_properties(vm_model_selection_tests PROPERTIES TIMEOUT 5)
+
+add_executable(vm_ml_opt_tests
+    testMlOpt.cxx
+)
+
+target_link_libraries(vm_ml_opt_tests PRIVATE
+    vm
+    Warnings
+)
+
+add_test(NAME vm_ml_opt_tests COMMAND vm_ml_opt_tests)
+set_tests_properties(vm_ml_opt_tests PROPERTIES TIMEOUT 5)

--- a/tests/testMlOpt.cxx
+++ b/tests/testMlOpt.cxx
@@ -1,0 +1,20 @@
+#include <cassert>
+#include <string>
+
+#include "ml_opt.hxx"
+
+int main() {
+    std::string s1 = "+-";
+    goof2::applyMlOptimizer(s1);
+    assert(s1 == "+");
+
+    std::string s2 = "-+";
+    goof2::applyMlOptimizer(s2);
+    assert(s2 == "-");
+
+    std::string s3 = "><";
+    goof2::applyMlOptimizer(s3);
+    assert(s3 == ">");
+
+    return 0;
+}

--- a/tools/generateMlModelHeader.py
+++ b/tools/generateMlModelHeader.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+
+
+def escape_cpp(s: str) -> str:
+    return s.replace('\\', r'\\').replace('"', r'\"')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate ml model header from text rules")
+    parser.add_argument('input', type=pathlib.Path)
+    parser.add_argument('output', type=pathlib.Path)
+    args = parser.parse_args()
+
+    rules = []
+    with args.input.open('r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or line.startswith('//'):
+                continue
+            parts = line.split('\t')
+            if len(parts) != 2:
+                continue
+            pattern, replacement = parts
+            rules.append((pattern, replacement))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open('w', encoding='utf-8') as out:
+        out.write('// Auto-generated from assets/ml_model.txt\n')
+        out.write('#pragma once\n\n')
+        out.write('namespace goof2 {\n')
+        out.write('struct MlRule { const char* pattern; const char* replacement; };\n')
+        out.write('inline constexpr MlRule mlModel[] = {\n')
+        for pattern, replacement in rules:
+            out.write(f'    {{R"({pattern})", "{escape_cpp(replacement)}"}},\n')
+        out.write('};\n')
+        out.write('inline constexpr size_t mlModelCount = sizeof(mlModel) / sizeof(mlModel[0]);\n')
+        out.write('} // namespace goof2\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- generate mlModel.hxx from assets/ml_model.txt during the build
- remove runtime model loading and use static regex rules
- add unit test verifying ml optimizer rules

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R vm_ml_opt_tests -V`


------
https://chatgpt.com/codex/tasks/task_e_689cccb0e0a483319f6bac1686eced6d