### PR TITLE
Preallocate regex replacement buffer

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -41,6 +41,7 @@ inline std::string processBalanced(std::string_view s, char no1, char no2) {
 template <typename Callback>
 inline void regexReplaceInplace(std::string& str, const std::regex& re, Callback cb) {
     std::string result;
+    result.reserve(str.size());
     auto begin = str.cbegin();
     auto end = str.cend();
     std::smatch match;


### PR DESCRIPTION
## Summary
- Reserve string capacity in `regexReplaceInplace` to avoid reallocations during regex replacements

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a738e3692c8331ad1d7728f846710a