### PR TITLE
docs: mention 64-bit cell width option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ printf 'A' | ./goof2 -e ',.'
 ./goof2 -e '+++' -nopt
 ```
 
-The VM supports selectable cell widths. Use the `--cw` option to choose 8-, 16- or 32-bit
+The VM supports selectable cell widths. Use the `--cw` option to choose 8-, 16-, 32- or 64-bit
 cells at startup:
 
 ```sh
-./goof2 --cw 16 program.bf
+./goof2 --cw 64 program.bf
 ```
 
 Add `--profile` to measure execution time and instruction count:


### PR DESCRIPTION
## Summary
- document selectable 64-bit cell width in README
- update example to use `--cw 64`

## Testing
- `rg '8-, 16-, 32- or 64-bit' README.md`
- `rg '8,16,32,64' -n`


------
https://chatgpt.com/codex/tasks/task_e_68a743ac47b083318ffd2ca6fb21815d