### PR TITLE
Add precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(goof2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 23)
@@ -81,12 +81,14 @@ if(NOT simde_POPULATED)
 endif()
 set(SIMDE_INCLUDE_DIR ${simde_SOURCE_DIR})
 
+set(PCH_HEADER src/pch.hxx)
 set(VM_SOURCES
     src/vm.cxx
     include/vm.hxx
 )
 
 add_library(vm ${VM_SOURCES})
+target_precompile_headers(vm PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${PCH_HEADER}>")
 target_include_directories(vm
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -109,11 +111,12 @@ if(GOOF2_ENABLE_REPL)
     )
 endif()
 
-set(PROJECT_SOURCES ${EXEC_SOURCES} ${VM_SOURCES})
+set(PROJECT_SOURCES ${EXEC_SOURCES} ${VM_SOURCES} ${PCH_HEADER})
 
 add_executable(goof2
     ${EXEC_SOURCES}
 )
+target_precompile_headers(goof2 REUSE_FROM vm)
 
 target_link_libraries(goof2 PRIVATE
     vm

--- a/src/pch.hxx
+++ b/src/pch.hxx
@@ -1,0 +1,16 @@
+/*
+    Goof2 - An optimizing brainfuck VM
+    Precompiled header
+    Published under the GNU AGPL-3.0-or-later license
+*/
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <ostream>
+#include <string>
+#include <vector>


### PR DESCRIPTION
## Summary
- Raise minimum CMake version to 3.16 and configure shared precompiled headers across targets.
- Introduce `pch.hxx` with common standard library includes and reuse it for both `vm` and `goof2` builds.

## Testing
- `cmake -S . -B build`

------
https://chatgpt.com/codex/tasks/task_e_68a7699dcef883319c4128b202a8dcad