### PR TITLE
Optimize clear-then-set sequences

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -125,6 +125,7 @@ static const std::regex clearLoopRe(R"([+-]*(?:\[[+-]+\])+)", optimize);
 static const std::regex scanLoopClrRe(R"(\[-[<>]+\]|\[[<>]\[-\]\])", optimize);
 static const std::regex scanLoopRe(R"(\[>+\]|\[<+\])", optimize);
 static const std::regex commaTrimRe(R"([+\-C]+,)", optimize);
+static const std::regex clearThenSetRe(R"(C([+-]+))", optimize);
 static const std::regex copyLoopRe(R"(\[-((?:[<>]+[+-]+)+)[<>]+\]|\[((?:[<>]+[+-]+)+)[<>]+-\])",
                                    optimize);
 static const std::regex leadingSetRe(R"((?:^|([RL\]]))C*([\+\-]+))", optimize);
@@ -559,6 +560,7 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
             });
 
             code = std::regex_replace(code, goof2::vmRegex::commaTrimRe, ",");
+            code = std::regex_replace(code, goof2::vmRegex::clearThenSetRe, "S$1");
 
             regexReplaceInplace(code, goof2::vmRegex::copyLoopRe, [&](const std::smatch& what) {
                 int numOfCopies = 0;

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -201,6 +201,20 @@ static void test_clr_range() {
 }
 
 template <typename CellT>
+static void test_clr_then_set() {
+    std::vector<CellT> cells(2, 1);
+    size_t ptr = 0;
+    std::string code = ">[-]++";
+    goof2::ProfileInfo profile;
+    goof2::execute<CellT>(cells, ptr, code, true, 0, true, false, goof2::MemoryModel::Auto,
+                          &profile);
+    assert(code == ">S++");
+    assert(ptr == 1);
+    assert(cells[1] == static_cast<CellT>(2));
+    assert(profile.instructions == 2);
+}
+
+template <typename CellT>
 static void run_tests() {
     test_loops<CellT>();
     test_io<CellT>();
@@ -210,6 +224,7 @@ static void run_tests() {
     test_scan_stride<CellT>();
     test_scan_clear<CellT>();
     test_clr_range<CellT>();
+    test_clr_then_set<CellT>();
     test_mul_cpy<CellT>();
 }
 


### PR DESCRIPTION
## Summary
- Collapse clear followed by additions into direct set operations via regex
- Add unit test covering clear-then-set optimization

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(failed: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a80881600c8331bf41dac476bccaa6