### PR TITLE
Optimize repeated clear tokens

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -129,6 +129,7 @@ static const std::regex copyLoopRe(R"(\[-((?:[<>]+[+-]+)+)[<>]+\]|\[((?:[<>]+[+-
                                    optimize);
 static const std::regex leadingSetRe(R"((?:^|([RL\]]))C*([\+\-]+))", optimize);
 static const std::regex copyLoopInnerRe(R"([<>]+[+-]+)", optimize);
+static const std::regex clearSeqRe(R"(C{2,})", optimize);
 }  // namespace goof2::vmRegex
 
 #include "simde/x86/avx2.h"
@@ -590,6 +591,8 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
             if constexpr (!Term)
                 code = std::regex_replace(code, goof2::vmRegex::leadingSetRe,
                                           "$1S$2");  // We can't really assume in term
+
+            code = std::regex_replace(code, goof2::vmRegex::clearSeqRe, "C");
         }
 
         std::vector<size_t> braceStack;


### PR DESCRIPTION
## Summary
- collapse consecutive clear commands in vm code

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a8092faa0c8331828d61c86dee314b