### PR TITLE
Add instruction cache for VM

### DIFF
--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -20,7 +20,34 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+enum class insType : uint8_t {
+    ADD_SUB,
+    SET,
+    PTR_MOV,
+    JMP_ZER,
+    JMP_NOT_ZER,
+    PUT_CHR,
+    RAD_CHR,
+    CLR,
+    CLR_RNG,
+    MUL_CPY,
+    SCN_RGT,
+    SCN_LFT,
+    SCN_CLR_RGT,
+    SCN_CLR_LFT,
+    END,
+};
+
+struct instruction {
+    const void* jump;
+    int32_t data;
+    int16_t auxData;
+    int16_t offset;
+    insType op = insType{};
+};
 
 namespace goof2 {
 #if GOOF2_HAS_OS_VM
@@ -35,6 +62,13 @@ struct ProfileInfo {
     double seconds = 0.0;
     std::vector<std::uint64_t> loopCounts{};
 };
+
+struct CacheEntry {
+    std::string source;
+    std::vector<instruction> instructions;
+};
+
+using InstructionCache = std::unordered_map<size_t, CacheEntry>;
 
 /// @brief Only function you should use in your code. For now, it always prints to stdout.
 /// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
@@ -61,5 +95,6 @@ template <typename CellT>
 int execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
             bool optimize = GOOF2_OPTIMIZE, int eof = GOOF2_DEFAULT_EOF_BEHAVIOUR,
             bool dynamicSize = GOOF2_DYNAMIC_CELLS_SIZE, bool term = GOOF2_DEFAULT_SAVE_STATE,
-            MemoryModel model = MemoryModel::Auto, ProfileInfo* profile = nullptr);
+            MemoryModel model = MemoryModel::Auto, ProfileInfo* profile = nullptr,
+            InstructionCache* cache = nullptr);
 }  // namespace goof2

--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <ranges>
 #include <regex>
@@ -22,8 +23,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-
-
 
 inline int32_t fold(std::string_view code, size_t& i, char match) {
     int32_t count = 1;
@@ -54,32 +53,6 @@ inline void regexReplaceInplace(std::string& str, const std::regex& re, Callback
     result.append(begin, end);
     str = std::move(result);
 }
-
-enum class insType : uint8_t {
-    ADD_SUB,
-    SET,
-    PTR_MOV,
-    JMP_ZER,
-    JMP_NOT_ZER,
-    PUT_CHR,
-    RAD_CHR,
-    CLR,
-    CLR_RNG,
-    MUL_CPY,
-    SCN_RGT,
-    SCN_LFT,
-    SCN_CLR_RGT,
-    SCN_CLR_LFT,
-    END,
-};
-
-struct instruction {
-    const void* jump;
-    int32_t data;
-    int16_t auxData;
-    int16_t offset;
-    insType op = insType{};
-};
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -507,9 +480,13 @@ constexpr std::array<insType, 256> charToOpcode = [] {
 
 template <typename CellT, bool Dynamic, bool Term, bool Sparse>
 int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
-                int eof, MemoryModel model, bool adaptive, goof2::ProfileInfo* profile) {
-    std::vector<instruction> instructions;
-    {
+                int eof, MemoryModel model, bool adaptive, goof2::ProfileInfo* profile,
+                std::vector<instruction>* cached) {
+    std::vector<instruction> localInstructions;
+    auto* instructionsPtr = cached ? cached : &localInstructions;
+    bool hasInstructions = cached && !cached->empty();
+    auto& instructions = *instructionsPtr;
+    if (!hasInstructions) {
         static void* jtable[] = {&&_ADD_SUB,     &&_SET,         &&_PTR_MOV, &&_JMP_ZER,
                                  &&_JMP_NOT_ZER, &&_PUT_CHR,     &&_RAD_CHR, &&_CLR,
                                  &&_CLR_RNG,     &&_MUL_CPY,     &&_SCN_RGT, &&_SCN_LFT,
@@ -1471,10 +1448,27 @@ static bool shouldUseSparse(std::string_view code) {
 
 template <typename CellT>
 int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, bool optimize,
-                   int eof, bool dynamicSize, bool term, MemoryModel model, ProfileInfo* profile) {
+                   int eof, bool dynamicSize, bool term, MemoryModel model, ProfileInfo* profile,
+                   InstructionCache* cache) {
     int ret = 0;
     auto start = std::chrono::steady_clock::now();
     if (profile) profile->instructions = 0;
+    size_t key = 0;
+    std::vector<instruction>* cacheVec = nullptr;
+    if (cache) {
+        key = std::hash<std::string>{}(code);
+        key ^= static_cast<size_t>(optimize) << 1;
+        key ^= static_cast<size_t>(term) << 2;
+        auto it = cache->find(key);
+        if (it != cache->end() && it->second.source == code) {
+            cacheVec = &it->second.instructions;
+        } else {
+            auto& entry = (*cache)[key];
+            entry.source = code;
+            entry.instructions.clear();
+            cacheVec = &entry.instructions;
+        }
+    }
     bool adaptive = (model == MemoryModel::Auto);
     if (adaptive) model = MemoryModel::Contiguous;
     bool sparse = shouldUseSparse(code);
@@ -1496,26 +1490,26 @@ int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code
     if (dynamicSize) {
         if (sparse) {
             term ? ret = executeImpl<CellT, true, true, true>(cells, cellPtr, code, optimize, eof,
-                                                              model, adaptive, profile)
+                                                              model, adaptive, profile, cacheVec)
                  : ret = executeImpl<CellT, true, false, true>(cells, cellPtr, code, optimize, eof,
-                                                               model, adaptive, profile);
+                                                               model, adaptive, profile, cacheVec);
         } else {
             term ? ret = executeImpl<CellT, true, true, false>(cells, cellPtr, code, optimize, eof,
-                                                               model, adaptive, profile)
+                                                               model, adaptive, profile, cacheVec)
                  : ret = executeImpl<CellT, true, false, false>(cells, cellPtr, code, optimize, eof,
-                                                                model, adaptive, profile);
+                                                                model, adaptive, profile, cacheVec);
         }
     } else {
         if (sparse) {
             term ? ret = executeImpl<CellT, false, true, true>(cells, cellPtr, code, optimize, eof,
-                                                               model, adaptive, profile)
+                                                               model, adaptive, profile, cacheVec)
                  : ret = executeImpl<CellT, false, false, true>(cells, cellPtr, code, optimize, eof,
-                                                                model, adaptive, profile);
+                                                                model, adaptive, profile, cacheVec);
         } else {
             term ? ret = executeImpl<CellT, false, true, false>(cells, cellPtr, code, optimize, eof,
-                                                                model, adaptive, profile)
-                 : ret = executeImpl<CellT, false, false, false>(cells, cellPtr, code, optimize,
-                                                                 eof, model, adaptive, profile);
+                                                                model, adaptive, profile, cacheVec)
+                 : ret = executeImpl<CellT, false, false, false>(
+                       cells, cellPtr, code, optimize, eof, model, adaptive, profile, cacheVec);
         }
     }
     if (profile)
@@ -1525,10 +1519,14 @@ int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code
 }
 
 template int goof2::execute<uint8_t>(std::vector<uint8_t>&, size_t&, std::string&, bool, int, bool,
-                                     bool, goof2::MemoryModel, goof2::ProfileInfo*);
+                                     bool, goof2::MemoryModel, goof2::ProfileInfo*,
+                                     goof2::InstructionCache*);
 template int goof2::execute<uint16_t>(std::vector<uint16_t>&, size_t&, std::string&, bool, int,
-                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*);
+                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*,
+                                      goof2::InstructionCache*);
 template int goof2::execute<uint32_t>(std::vector<uint32_t>&, size_t&, std::string&, bool, int,
-                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*);
+                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*,
+                                      goof2::InstructionCache*);
 template int goof2::execute<uint64_t>(std::vector<uint64_t>&, size_t&, std::string&, bool, int,
-                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*);
+                                      bool, bool, goof2::MemoryModel, goof2::ProfileInfo*,
+                                      goof2::InstructionCache*);

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -12,14 +12,15 @@
 template <typename CellT>
 static std::string run(std::string code, std::vector<CellT>& cells, size_t& cellPtr,
                        const std::string& input = "", int eof = 0, bool dynamicSize = true,
-                       int* retOut = nullptr, goof2::ProfileInfo* profile = nullptr) {
+                       int* retOut = nullptr, goof2::ProfileInfo* profile = nullptr,
+                       goof2::InstructionCache* cache = nullptr) {
     std::istringstream in(input);
     std::ostringstream out;
     auto* cinbuf = std::cin.rdbuf(in.rdbuf());
     auto* coutbuf = std::cout.rdbuf(out.rdbuf());
     std::cin.clear();
     int ret = goof2::execute<CellT>(cells, cellPtr, code, true, eof, dynamicSize, false,
-                                    goof2::MemoryModel::Auto, profile);
+                                    goof2::MemoryModel::Auto, profile, cache);
     if (retOut) *retOut = ret;
     std::cin.rdbuf(cinbuf);
     std::cout.rdbuf(coutbuf);
@@ -215,6 +216,23 @@ static void test_clr_then_set() {
 }
 
 template <typename CellT>
+static void test_cache_reuse() {
+    goof2::InstructionCache cache;
+    std::vector<CellT> cells(1, 0);
+    size_t ptr = 0;
+    run<CellT>("+", cells, ptr, "", 0, true, nullptr, nullptr, &cache);
+    assert(cells[0] == static_cast<CellT>(1));
+    cells[0] = 0;
+    ptr = 0;
+    run<CellT>("+", cells, ptr, "", 0, true, nullptr, nullptr, &cache);
+    assert(cells[0] == static_cast<CellT>(1));
+    cells[0] = 0;
+    ptr = 0;
+    run<CellT>("++", cells, ptr, "", 0, true, nullptr, nullptr, &cache);
+    assert(cells[0] == static_cast<CellT>(2));
+}
+
+template <typename CellT>
 static void run_tests() {
     test_loops<CellT>();
     test_io<CellT>();
@@ -226,6 +244,7 @@ static void run_tests() {
     test_clr_range<CellT>();
     test_clr_then_set<CellT>();
     test_mul_cpy<CellT>();
+    test_cache_reuse<CellT>();
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- add reusable instruction cache and extend VM execute API
- cache compiled instruction sequences keyed by source and flags
- test multiple executions with cache reuse and invalidation

## Testing
- `cmake -S . -B build -DGOOF2_ENABLE_REPL=OFF -Dsimde_SOURCE_DIR=simde` (fails: Failed to checkout tag: '7da3fb1d7f9ad859290f7141403036c3c90bf668')

------
https://chatgpt.com/codex/tasks/task_e_68bc761bda2c8331ac83eddfdb964913