### PR TITLE
Use OS remap when expanding memory

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,3 +13,8 @@ It includes third-party components under separate licenses:
 
 - cpp-terminal (MIT), see `../cpp-terminal/LICENSE`
 - simde (MIT and CC0), see `../simde/COPYING`
+
+## Platform Notes
+
+See [OS-backed memory expansion](os-memory.md) for details on how goof2 grows
+its tape on different platforms.

--- a/docs/os-memory.md
+++ b/docs/os-memory.md
@@ -1,0 +1,11 @@
+# OS-backed memory expansion
+
+The virtual machine can grow its tape using operating system primitives when
+using the OS-backed memory model.
+
+- **Linux**: existing mappings are extended with [`mremap(2)`](https://man7.org/linux/man-pages/man2/mremap.2.html).
+- **Windows**: additional pages are committed with `VirtualAlloc` and
+  `MEM_COMMIT`.
+
+If these platform APIs fail, goof2 falls back to allocating a new region and
+copying the previous contents.

--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -4,6 +4,11 @@
     Published under the GNU AGPL-3.0-or-later license
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
+#if defined(__linux__)
+#define _GNU_SOURCE
+#endif
+
 #include "vm.hxx"
 
 #include <algorithm>
@@ -22,8 +27,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-
-
 
 inline int32_t fold(std::string_view code, size_t& i, char match) {
     int32_t count = 1;
@@ -861,28 +864,50 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
 #if GOOF2_HAS_OS_VM
                 size_t newSize = ((needed + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
                 if (newSize > osSize) {
-                    void* nptr = goof2::os_alloc(newSize * sizeof(CellT));
-#ifdef _WIN32
-                    bool ok = nptr != nullptr;
-#else
-                    bool ok = nptr != MAP_FAILED;
-#endif
-                    if (ok) {
-                        CellT* newMem = static_cast<CellT*>(nptr);
-                        std::memcpy(newMem, cellBase, osSize * sizeof(CellT));
-                        goof2::os_free(cellBase, osSize * sizeof(CellT));
-                        cellBase = newMem;
+                    bool resized = false;
+#if defined(__linux__)
+                    void* mptr = mremap(cellBase, osSize * sizeof(CellT), newSize * sizeof(CellT),
+                                        MREMAP_MAYMOVE);
+                    if (mptr != MAP_FAILED) {
+                        cellBase = static_cast<CellT*>(mptr);
                         osSize = newSize;
-                    } else {
-                        std::cerr << "warning: OS-backed allocation failed, falling back to "
-                                     "contiguous memory model"
-                                  << std::endl;
-                        cells.resize(newSize);
-                        std::memcpy(cells.data(), cellBase, osSize * sizeof(CellT));
-                        goof2::os_free(cellBase, osSize * sizeof(CellT));
-                        cellBase = cells.data();
-                        osSize = cells.size();
-                        model = MemoryModel::Contiguous;
+                        resized = true;
+                    }
+#elif defined(_WIN32)
+                    auto basePtr = reinterpret_cast<uint8_t*>(cellBase);
+                    void* mptr = VirtualAlloc(basePtr + osSize * sizeof(CellT),
+                                              (newSize - osSize) * sizeof(CellT), MEM_COMMIT,
+                                              PAGE_READWRITE);
+                    if (mptr) {
+                        osSize = newSize;
+                        resized = true;
+                    }
+#endif
+                    if (!resized) {
+                        void* nptr = goof2::os_alloc(newSize * sizeof(CellT));
+#ifdef _WIN32
+                        bool ok = nptr != nullptr;
+#else
+                        bool ok = nptr != MAP_FAILED;
+#endif
+                        if (ok) {
+                            CellT* newMem = static_cast<CellT*>(nptr);
+                            std::memcpy(newMem, cellBase, osSize * sizeof(CellT));
+                            goof2::os_free(cellBase, osSize * sizeof(CellT));
+                            cellBase = newMem;
+                            osSize = newSize;
+                        } else {
+                            std::cerr << "warning: OS-backed allocation failed, falling back to "
+                                         "contiguous "
+                                         "memory model"
+                                      << std::endl;
+                            cells.resize(newSize);
+                            std::memcpy(cells.data(), cellBase, osSize * sizeof(CellT));
+                            goof2::os_free(cellBase, osSize * sizeof(CellT));
+                            cellBase = cells.data();
+                            osSize = cells.size();
+                            model = MemoryModel::Contiguous;
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
## Summary
- Extend OS-backed memory using `mremap` on Linux or `VirtualAlloc` on Windows
- Fallback to allocation-and-copy when remapping fails
- Document platform-specific memory behavior

## Testing
- `cmake -S . -B build -DGOOF2_ENABLE_REPL=OFF` *(fails: reference is not a tree for simde)*
- `ctest --test-dir build` *(no tests due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7624c91c833197223c5ee7dd789c