### PR TITLE
Use pmr vector for instruction storage

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -577,8 +577,8 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
                     std::smatch whatL;
                     auto start = current.cbegin();
                     auto end = current.cend();
-                    std::unordered_map<int, int> deltaMap;
-                    std::vector<int> order;
+                    std::pmr::unordered_map<int, int> deltaMap{&instructionPool};
+                    std::pmr::vector<int> order{&instructionPool};
                     while (std::regex_search(start, end, whatL, goof2::vmRegex::copyLoopInnerRe)) {
                         offset += -std::count(whatL[0].first, whatL[0].second, '<') +
                                   std::count(whatL[0].first, whatL[0].second, '>');


### PR DESCRIPTION
## Summary
- use `std::pmr::vector` with a local `std::pmr::monotonic_buffer_resource` for instructions
- allocate helper vectors from the same memory resource to limit dynamic allocations

## Testing
- `cmake -S . -B build -DGOOF2_ENABLE_REPL=OFF` *(fails: Failed to checkout tag: '7da3fb1d7f9ad859290f7141403036c3c90bf668')*

------
https://chatgpt.com/codex/tasks/task_e_68bc763a6ba88331831e0be80dfbc2bb