### PR TITLE
Refactor line parsing to avoid istringstream

### DIFF
--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -13,9 +13,9 @@ template <typename CellT>
 static std::string run(std::string code, std::vector<CellT>& cells, size_t& cellPtr,
                        const std::string& input = "", int eof = 0, bool dynamicSize = true,
                        int* retOut = nullptr, goof2::ProfileInfo* profile = nullptr) {
-    std::istringstream in(input);
+    std::stringbuf in(input);
     std::ostringstream out;
-    auto* cinbuf = std::cin.rdbuf(in.rdbuf());
+    auto* cinbuf = std::cin.rdbuf(&in);
     auto* coutbuf = std::cout.rdbuf(out.rdbuf());
     std::cin.clear();
     int ret = goof2::execute<CellT>(cells, cellPtr, code, true, eof, dynamicSize, false,

--- a/tests/test_load.cxx
+++ b/tests/test_load.cxx
@@ -16,9 +16,9 @@ static std::string runFile(const std::string& path, std::vector<CellT>& cells, s
                            const std::string& input = "") {
     std::ifstream file(path);
     std::string code((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    std::istringstream in(input);
+    std::stringbuf in(input);
     std::ostringstream out;
-    auto* cinbuf = std::cin.rdbuf(in.rdbuf());
+    auto* cinbuf = std::cin.rdbuf(&in);
     auto* coutbuf = std::cout.rdbuf(out.rdbuf());
     std::cin.clear();
     goof2::execute<CellT>(cells, cellPtr, code, true, 0, true, false);


### PR DESCRIPTION
## Summary
- replace `std::istringstream` usage with manual newline scanning and direct substring insertion
- use `std::stringbuf` and manual parsing in tests and fuzz harness

## Testing
- `cmake -S . -B build` *(fails: Failed to checkout tag for cpp-terminal)*

------
https://chatgpt.com/codex/tasks/task_e_68bc76faff3c83318431c5964244714d