### PR TITLE
Return early in shouldUseSparse when span exceeds threshold

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -1460,13 +1460,19 @@ static bool shouldUseSparse(std::string_view code) {
     for (char c : code) {
         if (c == '>') {
             ++pos;
-            if (pos > maxPos) maxPos = pos;
+            if (pos > maxPos) {
+                maxPos = pos;
+                if ((maxPos - minPos) > 100000) return true;
+            }
         } else if (c == '<') {
             --pos;
-            if (pos < minPos) minPos = pos;
+            if (pos < minPos) {
+                minPos = pos;
+                if ((maxPos - minPos) > 100000) return true;
+            }
         }
     }
-    return (maxPos - minPos) > 100000;  // trigger sparse when span exceeds 100k cells
+    return false;  // sparse memory not needed when span stays within 100k cells
 }
 
 template <typename CellT>


### PR DESCRIPTION
## Summary
- return immediately from `shouldUseSparse` once the data pointer span exceeds 100k cells

## Testing
- `cmake -S . -B build` *(fails: Failed to checkout tag dfb5ddf47dca73ce3cb51e3b8a80f2485bb74dff for cpp-terminal)*

------
https://chatgpt.com/codex/tasks/task_e_68bc767bb0b48331970eacda30eacb02