### PR TITLE
Fix build issues

### DIFF
--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -156,7 +156,7 @@ std::string render(Term::Window& scr, const std::vector<std::string>& log,
     for (std::size_t i = 0; i < inputLines; ++i) {
         std::size_t row = logHeight + 2 + i;
         scr.print_str(1, row, i == 0 ? "$ " : "  ");
-        scr.print_str(3, row, lines[i]);
+        scr.print_str(3, row, std::string(lines[i]));
         highlightBf(scr, 3, row, lines[i]);
     }
 

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -231,7 +231,9 @@ static void test_unmatched_brackets() {
         run<CellT>("[", cells, ptr, "", 0, true, &ret);
         assert(ret == 2);
     }
+}
 
+template <typename CellT>
 static void test_cache_reuse() {
     goof2::InstructionCache cache;
     std::vector<CellT> cells(1, 0);


### PR DESCRIPTION
## Summary
- Fix REPL string handling by converting string_view to string when printing
- Correct unit test definitions for cache reuse checks

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b39f0f48331a04243d8c42d2832