### PR TITLE
Use nosubs for regexes without captures

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -100,19 +100,19 @@ using goof2::MemoryModel;
 
 namespace goof2::vmRegex {
 using namespace std::regex_constants;
-static const std::regex nonInstructionRe(R"([^+\-<>\.,\]\[])", optimize);
-static const std::regex addSubSeqRe(R"([+-]{2,})", optimize);
-static const std::regex ptrSeqRe(R"([><]{2,})", optimize);
-static const std::regex clearLoopRe(R"([+-]*(?:\[[+-]+\])+)", optimize);
-static const std::regex scanLoopClrRe(R"(\[-[<>]+\]|\[[<>]\[-\]\])", optimize);
-static const std::regex scanLoopRe(R"(\[[<>]+\])", optimize);
-static const std::regex commaTrimRe(R"([+\-C]+,)", optimize);
+static const std::regex nonInstructionRe(R"([^+\-<>\.,\]\[])", optimize | nosubs);
+static const std::regex addSubSeqRe(R"([+-]{2,})", optimize | nosubs);
+static const std::regex ptrSeqRe(R"([><]{2,})", optimize | nosubs);
+static const std::regex clearLoopRe(R"([+-]*(?:\[[+-]+\])+)", optimize | nosubs);
+static const std::regex scanLoopClrRe(R"(\[-[<>]+\]|\[[<>]\[-\]\])", optimize | nosubs);
+static const std::regex scanLoopRe(R"(\[[<>]+\])", optimize | nosubs);
+static const std::regex commaTrimRe(R"([+\-C]+,)", optimize | nosubs);
 static const std::regex clearThenSetRe(R"(C([+-]+))", optimize);
 static const std::regex copyLoopRe(R"(\[-((?:[<>]+[+-]+)+)[<>]+\]|\[((?:[<>]+[+-]+)+)[<>]+-\])",
                                    optimize);
 static const std::regex leadingSetRe(R"((?:^|([RL\]]))C*([\+\-]+))", optimize);
-static const std::regex copyLoopInnerRe(R"([<>]+[+-]+)", optimize);
-static const std::regex clearSeqRe(R"(C{2,})", optimize);
+static const std::regex copyLoopInnerRe(R"([<>]+[+-]+)", optimize | nosubs);
+static const std::regex clearSeqRe(R"(C{2,})", optimize | nosubs);
 }  // namespace goof2::vmRegex
 
 #include "simde/x86/avx2.h"


### PR DESCRIPTION
## Summary
- avoid unnecessary match data by adding `nosubs` to regexes with no captured groups

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd6648e508331b44833ad3f0d392b