### PR TITLE
Reserve loop optimization maps before regex passes

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -566,10 +566,13 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
 
         int copyloopCounter = 0;
         std::vector<int> copyloopMap;
+        copyloopMap.reserve(code.size() / 2);
 
         int scanloopCounter = 0;
         std::vector<int> scanloopMap;
+        scanloopMap.reserve(code.size() / 2);
         std::vector<bool> scanloopClrMap;
+        scanloopClrMap.reserve(code.size() / 2);
 
         if (optimize) {
             regexReplaceInplace(code, goof2::vmRegex::nonInstructionRe,


### PR DESCRIPTION
## Summary
- Reserve capacity for copy loop, scan loop, and clear scan loop maps before regex optimizations

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `ctest --test-dir build` *(fails: vm_cli_eval_tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd89a07548331bad7e95beb1b5cb9