### PR TITLE
Use string_view in regex regexReplaceInplace

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -213,6 +213,7 @@ int main(int argc, char* argv[]) {
                           << " Unsupported cell width; use 8,16,32,64" << std::endl;
                 return 1;
         }
+        std::cout.flush();
         return 0;
     }
     if (!filename.empty()) {
@@ -430,6 +431,7 @@ int main(int argc, char* argv[]) {
             std::cerr << "ERROR: Unsupported cell width; use 8,16,32,64" << std::endl;
             return 1;
     }
+    std::cout.flush();
     if (profile) {
         std::cout << "Instructions executed: " << prof.instructions << std::endl;
         std::cout << "Elapsed time: " << prof.seconds << "s" << std::endl;

--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -53,12 +53,14 @@ template <typename Callback>
 inline void regexReplaceInplace(std::string& str, const std::regex& re, Callback cb) {
     std::string result;
     result.reserve(str.size());
-    auto begin = str.cbegin();
-    auto end = str.cend();
-    std::smatch match;
+    std::string_view sv = str;
+    auto begin = sv.cbegin();
+    auto end = sv.cend();
+    std::match_results<std::string_view::const_iterator> match;
     while (std::regex_search(begin, end, match, re)) {
         result.append(begin, match[0].first);
-        result += cb(match);
+        auto replacement = cb(match);
+        result += replacement;
         begin = match[0].second;
     }
     result.append(begin, end);
@@ -574,100 +576,127 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
 
         if (optimize) {
             regexReplaceInplace(code, goof2::vmRegex::nonInstructionRe,
-                                [](const std::smatch&) { return std::string{}; });
+                                [](const std::match_results<std::string_view::const_iterator>&) {
+                                    return std::string{};
+                                });
 
-            regexReplaceInplace(code, goof2::vmRegex::addSubSeqRe, [&](const std::smatch& what) {
-                return processBalanced(what.str(), '+', '-');
-            });
-            regexReplaceInplace(code, goof2::vmRegex::ptrSeqRe, [&](const std::smatch& what) {
-                return processBalanced(what.str(), '>', '<');
-            });
+            regexReplaceInplace(
+                code, goof2::vmRegex::addSubSeqRe,
+                [&](const std::match_results<std::string_view::const_iterator>& what) {
+                    std::string_view sv(what[0].first, what[0].second - what[0].first);
+                    return processBalanced(sv, '+', '-');
+                });
+            regexReplaceInplace(
+                code, goof2::vmRegex::ptrSeqRe,
+                [&](const std::match_results<std::string_view::const_iterator>& what) {
+                    std::string_view sv(what[0].first, what[0].second - what[0].first);
+                    return processBalanced(sv, '>', '<');
+                });
 
             regexReplaceInplace(code, goof2::vmRegex::clearLoopRe,
-                                [](const std::smatch&) { return std::string("C"); });
+                                [](const std::match_results<std::string_view::const_iterator>&) {
+                                    return std::string("C");
+                                });
 
-            regexReplaceInplace(code, goof2::vmRegex::scanLoopClrRe, [&](const std::smatch& what) {
-                const auto current = what.str();
-                const auto count =
-                    std::ranges::count(current, '>') - std::ranges::count(current, '<');
-                scanloopMap.push_back(std::abs(count));
-                scanloopClrMap.push_back(true);
-                if (count > 0)
-                    return std::string("R");
-                else if (count == 0)
-                    return current;
-                else
-                    return std::string("L");
-            });
+            regexReplaceInplace(
+                code, goof2::vmRegex::scanLoopClrRe,
+                [&](const std::match_results<std::string_view::const_iterator>& what) {
+                    std::string_view current(what[0].first, what[0].second - what[0].first);
+                    const auto count =
+                        std::ranges::count(current, '>') - std::ranges::count(current, '<');
+                    scanloopMap.push_back(std::abs(count));
+                    scanloopClrMap.push_back(true);
+                    if (count > 0)
+                        return std::string("R");
+                    else if (count == 0)
+                        return std::string(current);
+                    else
+                        return std::string("L");
+                });
 
-            regexReplaceInplace(code, goof2::vmRegex::scanLoopRe, [&](const std::smatch& what) {
-                const auto current = what.str();
-                const auto count =
-                    std::ranges::count(current, '>') - std::ranges::count(current, '<');
-                scanloopMap.push_back(std::abs(count));
-                scanloopClrMap.push_back(false);
-                if (count > 0)
-                    return std::string("R");
-                else
-                    return std::string("L");
-            });
+            regexReplaceInplace(
+                code, goof2::vmRegex::scanLoopRe,
+                [&](const std::match_results<std::string_view::const_iterator>& what) {
+                    std::string_view current(what[0].first, what[0].second - what[0].first);
+                    const auto count =
+                        std::ranges::count(current, '>') - std::ranges::count(current, '<');
+                    scanloopMap.push_back(std::abs(count));
+                    scanloopClrMap.push_back(false);
+                    if (count > 0)
+                        return std::string("R");
+                    else
+                        return std::string("L");
+                });
 
             regexReplaceInplace(code, goof2::vmRegex::commaTrimRe,
-                                [](const std::smatch&) { return std::string(","); });
-            regexReplaceInplace(code, goof2::vmRegex::clearThenSetRe, [](const std::smatch& what) {
-                return std::string("S") + what[1].str();
-            });
+                                [](const std::match_results<std::string_view::const_iterator>&) {
+                                    return std::string(",");
+                                });
+            regexReplaceInplace(
+                code, goof2::vmRegex::clearThenSetRe,
+                [](const std::match_results<std::string_view::const_iterator>& what) {
+                    return std::string("S") + std::string(what[1].first, what[1].second);
+                });
 
-            regexReplaceInplace(code, goof2::vmRegex::copyLoopRe, [&](const std::smatch& what) {
-                int offset = 0;
-                const std::string whole = what.str();
-                const std::string current = what[1].str() + what[2].str();
+            regexReplaceInplace(
+                code, goof2::vmRegex::copyLoopRe,
+                [&](const std::match_results<std::string_view::const_iterator>& what) {
+                    int offset = 0;
+                    std::string_view whole(what[0].first, what[0].second - what[0].first);
+                    const std::string currentStr = std::string(what[1].first, what[1].second) +
+                                                   std::string(what[2].first, what[2].second);
 
-                if (std::count(whole.begin(), whole.end(), '>') -
-                        std::count(whole.begin(), whole.end(), '<') ==
-                    0) {
-                    std::smatch whatL;
-                    auto start = current.cbegin();
-                    auto end = current.cend();
-                    std::unordered_map<int, int> deltaMap;
-                    std::vector<int> order;
-                    while (std::regex_search(start, end, whatL, goof2::vmRegex::copyLoopInnerRe)) {
-                        offset += -std::count(whatL[0].first, whatL[0].second, '<') +
-                                  std::count(whatL[0].first, whatL[0].second, '>');
-                        int delta = std::count(whatL[0].first, whatL[0].second, '+') -
-                                    std::count(whatL[0].first, whatL[0].second, '-');
-                        if (deltaMap.insert({offset, delta}).second) {
-                            order.push_back(offset);
-                        } else {
-                            deltaMap[offset] += delta;
+                    if (std::count(whole.begin(), whole.end(), '>') -
+                            std::count(whole.begin(), whole.end(), '<') ==
+                        0) {
+                        std::match_results<std::string_view::const_iterator> whatL;
+                        std::string_view current = currentStr;
+                        auto start = current.cbegin();
+                        auto end = current.cend();
+                        std::unordered_map<int, int> deltaMap;
+                        std::vector<int> order;
+                        while (
+                            std::regex_search(start, end, whatL, goof2::vmRegex::copyLoopInnerRe)) {
+                            offset += -std::count(whatL[0].first, whatL[0].second, '<') +
+                                      std::count(whatL[0].first, whatL[0].second, '>');
+                            int delta = std::count(whatL[0].first, whatL[0].second, '+') -
+                                        std::count(whatL[0].first, whatL[0].second, '-');
+                            if (deltaMap.insert({offset, delta}).second) {
+                                order.push_back(offset);
+                            } else {
+                                deltaMap[offset] += delta;
+                            }
+                            start = whatL[0].second;
                         }
-                        start = whatL[0].second;
-                    }
-                    // Check if every target's accumulated delta is zero.
-                    const bool allZero = std::ranges::all_of(
-                        deltaMap, [](const auto& it) { return it.second == 0; });
-                    if (!allZero) {
-                        for (const auto& off : order) {
-                            copyloopMap.push_back(off);
-                            copyloopMap.push_back(deltaMap[off]);
+                        // Check if every target's accumulated delta is zero.
+                        const bool allZero = std::ranges::all_of(
+                            deltaMap, [](const auto& it) { return it.second == 0; });
+                        if (!allZero) {
+                            for (const auto& off : order) {
+                                copyloopMap.push_back(off);
+                                copyloopMap.push_back(deltaMap[off]);
+                            }
+                            return std::string(order.size(), 'P') + "C";
                         }
-                        return std::string(order.size(), 'P') + "C";
+                        // When all deltas are zero, drop the P instructions and only clear.
+                        return std::string("C");
+                    } else {
+                        return std::string(whole);
                     }
-                    // When all deltas are zero, drop the P instructions and only clear.
-                    return std::string("C");
-                } else {
-                    return whole;
-                }
-            });
+                });
 
             if constexpr (!Term)
-                regexReplaceInplace(code, goof2::vmRegex::leadingSetRe,
-                                    [](const std::smatch& what) {
-                                        return what[1].str() + std::string("S") + what[2].str();
-                                    });  // We can't really assume in term
+                regexReplaceInplace(
+                    code, goof2::vmRegex::leadingSetRe,
+                    [](const std::match_results<std::string_view::const_iterator>& what) {
+                        return std::string(what[1].first, what[1].second) + std::string("S") +
+                               std::string(what[2].first, what[2].second);
+                    });  // We can't really assume in term
 
             regexReplaceInplace(code, goof2::vmRegex::clearSeqRe,
-                                [](const std::smatch&) { return std::string("C"); });
+                                [](const std::match_results<std::string_view::const_iterator>&) {
+                                    return std::string("C");
+                                });
         }
 
         std::vector<size_t> braceTable(code.length());


### PR DESCRIPTION
## Summary
- Replace `std::smatch` with `std::match_results<std::string_view::const_iterator>` in `regexReplaceInplace`
- Drive regex replacements using `std::string_view` iterators to reduce temporary strings
- Update all regex optimization callbacks to accept these string-view match results
- Flush standard output after command-line executions to ensure pipes capture output

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R vm_cli_eval_tests` *(failed: Timeout)*
- `ctest --test-dir build -R vm_execute_tests`

------
https://chatgpt.com/codex/tasks/task_e_68bcd66ba61c83318ca4d13947bc107a