### PR TITLE
Set unity build batch size to 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_UNITY_BUILD ON)
+set(CMAKE_UNITY_BUILD_BATCH_SIZE 16)
 
 # Use a compiler cache if available to speed up rebuilds
 # Prefer sccache (great on Windows/macOS/Linux), then fall back to ccache/clcache


### PR DESCRIPTION
## Summary
- configure unity build to process 16 files per batch to reduce compile time

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bce391753c8331906729fa2208df5d