### PR TITLE
Refine loop regex quantifiers

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -121,7 +121,7 @@ namespace goof2::vmRegex {
 using namespace std::regex_constants;
 static const std::regex nonInstructionRe(R"([^+\-<>\.,\]\[])", optimize | nosubs);
 static const std::regex balanceSeqRe(R"([+-]{2,}|[><]{2,})", optimize | nosubs);
-static const std::regex clearLoopRe(R"([+-]*(?:\[[+-]+\])+)", optimize | nosubs);
+static const std::regex clearLoopRe(R"([+-]*\[[+-]+\](?:\[[+-]+\])*)", optimize | nosubs);
 static const std::regex scanLoopClrRe(R"(\[-[<>]+\]|\[[<>]\[-\]\])", optimize | nosubs);
 static const std::regex scanLoopRe(R"(\[[<>]+\])", optimize | nosubs);
 static const std::regex commaTrimRe(R"([+\-C]+,)", optimize | nosubs);
@@ -129,7 +129,7 @@ static const std::regex clearThenSetRe(R"(C([+-]+))", optimize);
 static const std::regex copyLoopRe(R"(\[-((?:[<>]+[+-]+)+)[<>]+\]|\[((?:[<>]+[+-]+)+)[<>]+-\])",
                                    optimize);
 static const std::regex leadingSetRe(R"((?:^|([RL\]]))C*([\+\-]+))", optimize);
-static const std::regex copyLoopInnerRe(R"([<>]+[+-]+)", optimize | nosubs);
+static const std::regex copyLoopInnerRe(R"((?:<+|>+)[+-]+)", optimize | nosubs);
 static const std::regex clearSeqRe(R"(C{2,})", optimize | nosubs);
 }  // namespace goof2::vmRegex
 


### PR DESCRIPTION
## Summary
- tighten clear loop regex to avoid ambiguous nested quantifiers
- restrict copy loop inner pattern to single-direction pointer runs

## Testing
- `cmake --build build` (pass)
- `ctest --test-dir build` (fail: vm_execute_tests, vm_alloc_fail_tests)`

------
https://chatgpt.com/codex/tasks/task_e_68bce6df3a5c8331a217edfc645dd02b