### PR TITLE
Patch cpp-terminal Windows version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if(GOOF2_ENABLE_REPL)
             GIT_REPOSITORY https://github.com/jupyter-xeus/cpp-terminal
             GIT_TAG a5c1d2619c96ae609357a7109076000b05ad006c
             GIT_SHALLOW TRUE
+            PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/cpp-terminal-winternl.patch
         )
         FetchContent_MakeAvailable(cpp-terminal)
     endif()

--- a/cmake/patches/cpp-terminal-winternl.patch
+++ b/cmake/patches/cpp-terminal-winternl.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp-terminal/private/terminfo.cpp b/cpp-terminal/private/terminfo.cpp
+index d7c5f39..6943304 100644
+--- a/cpp-terminal/private/terminfo.cpp
++++ b/cpp-terminal/private/terminfo.cpp
+@@ -11,6 +11,7 @@
+   #pragma warning(push)
+   #pragma warning(disable : 4668)
+   #include <windows.h>
++#include <winternl.h>
+   #pragma warning(pop)
+ #endif
+ 


### PR DESCRIPTION
## Summary
- patch cpp-terminal to include `<winternl.h>` so RtlGetVersion is declared on Windows
- apply patch automatically when fetching dependency

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3f03a73083318fa70e67c4eda6c3