### PR TITLE
Refine GNU source guard for Windows build

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -5,8 +5,10 @@
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-#if defined(__linux__)
+#ifdef __linux__
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #endif
 
 #include "vm.hxx"


### PR DESCRIPTION
## Summary
- guard `_GNU_SOURCE` with nested conditionals so it is only defined on Linux

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bd41bbba388331b81627759bcedd36