### PR TITLE
Fix cpp-terminal patch application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(GOOF2_ENABLE_REPL)
             GIT_REPOSITORY https://github.com/jupyter-xeus/cpp-terminal
             GIT_TAG a5c1d2619c96ae609357a7109076000b05ad006c
             GIT_SHALLOW TRUE
-            PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/cpp-terminal-winternl.patch
+            PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/cpp-terminal-winternl.patch
         )
         FetchContent_MakeAvailable(cpp-terminal)
     endif()

--- a/cmake/patches/cpp-terminal-winternl.patch
+++ b/cmake/patches/cpp-terminal-winternl.patch
@@ -1,12 +1,12 @@
 diff --git a/cpp-terminal/private/terminfo.cpp b/cpp-terminal/private/terminfo.cpp
-index d7c5f39..6943304 100644
+index d7c5f39..3da6ee2 100644
 --- a/cpp-terminal/private/terminfo.cpp
 +++ b/cpp-terminal/private/terminfo.cpp
 @@ -11,6 +11,7 @@
    #pragma warning(push)
    #pragma warning(disable : 4668)
    #include <windows.h>
-+#include <winternl.h>
++  #include <winternl.h>
    #pragma warning(pop)
  #endif
  


### PR DESCRIPTION
## Summary
- refresh winternl patch for cpp-terminal and apply it ignoring whitespace

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: build interrupted, environment timeout)*
- `ctest --test-dir build` *(fails: build executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd47a2ac148331ae8e05cc8390a7f3