### PR TITLE
Replace Brainfuck character switch with lookup table

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -5,6 +5,7 @@
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
@@ -83,21 +84,23 @@ struct MappedFile {
     }
 };
 
-static bool isBfChar(char c) {
-    switch (c) {
-        case '+':
-        case '-':
-        case '>':
-        case '<':
-        case '[':
-        case ']':
-        case '.':
-        case ',':
-            return true;
-        default:
-            return false;
-    }
-}
+#ifdef NDEBUG
+[[maybe_unused]]
+#endif
+constexpr std::array<bool, 256> bfTable = [] {
+    std::array<bool, 256> table{};
+    table[static_cast<unsigned char>('+')] = true;
+    table[static_cast<unsigned char>('-')] = true;
+    table[static_cast<unsigned char>('>')] = true;
+    table[static_cast<unsigned char>('<')] = true;
+    table[static_cast<unsigned char>('[')] = true;
+    table[static_cast<unsigned char>(']')] = true;
+    table[static_cast<unsigned char>('.')] = true;
+    table[static_cast<unsigned char>(',')] = true;
+    return table;
+}();
+
+static bool isBfChar(char c) { return bfTable[static_cast<unsigned char>(c)]; }
 
 static bool mapFileReadOnly(const std::string& path, MappedFile& mf) {
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- add constexpr table for Brainfuck character detection and use it in isBfChar
- include <array> and mark table [[maybe_unused]] in release builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bda16c3bf08331870fc5ad358ebce5