### PR TITLE
Hash test outputs with xxHash

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(vm_execute_tests
 target_link_libraries(vm_execute_tests PRIVATE
     vm
     Warnings
+    xxhash
 )
 target_precompile_headers(vm_execute_tests REUSE_FROM vm)
 
@@ -24,6 +25,7 @@ add_executable(vm_alloc_fail_tests
 target_link_libraries(vm_alloc_fail_tests PRIVATE
     vm
     Warnings
+    xxhash
 )
 target_precompile_headers(vm_alloc_fail_tests REUSE_FROM vm)
 
@@ -37,6 +39,7 @@ add_executable(vm_memory_model_tests
 target_link_libraries(vm_memory_model_tests PRIVATE
     vm
     Warnings
+    xxhash
 )
 target_precompile_headers(vm_memory_model_tests REUSE_FROM vm)
 
@@ -50,6 +53,7 @@ add_executable(vm_load_file_tests
 target_link_libraries(vm_load_file_tests PRIVATE
     vm
     Warnings
+    xxhash
 )
 target_precompile_headers(vm_load_file_tests REUSE_FROM vm)
 
@@ -78,6 +82,7 @@ if(NOT GOOF2_ENABLE_REPL)
 
     target_link_libraries(vm_cli_eval_tests PRIVATE
         Warnings
+        xxhash
     )
     target_precompile_headers(vm_cli_eval_tests REUSE_FROM vm)
 

--- a/tests/helpers.hxx
+++ b/tests/helpers.hxx
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <xxhash.h>
+
+#include <cstdint>
+#include <string_view>
+
+inline std::uint64_t hashOutput(std::string_view s) { return XXH64(s.data(), s.size(), 0); }

--- a/tests/test_cli_eval.cxx
+++ b/tests/test_cli_eval.cxx
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "helpers.hxx"
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -75,10 +77,10 @@ static std::string run_inline(const std::string& code, const std::string& extra 
 int main() {
     const std::string helloA = "++++++++[>++++++++<-]>+.";  // prints 'A'
     std::string out = run_inline(helloA);
-    assert(out == "A");
+    assert(hashOutput(out) == 0x13099d40d095b684ULL);
     out = run_inline(helloA, "-nopt");
-    assert(out == "A");
+    assert(hashOutput(out) == 0x13099d40d095b684ULL);
     out = run_inline(helloA, "-i nofile.bf");
-    assert(out == "A");
+    assert(hashOutput(out) == 0x13099d40d095b684ULL);
     return 0;
 }

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "helpers.hxx"
 #include "vm.hxx"
 
 template <typename CellT>
@@ -41,7 +42,7 @@ static void test_io() {
     std::vector<CellT> cells(1, 0);
     size_t ptr = 0;
     std::string out = run<CellT>(",.", cells, ptr, "A");
-    assert(out == "A");
+    assert(hashOutput(out) == 0x13099d40d095b684ULL);
     assert(cells[0] == static_cast<CellT>('A'));
 }
 

--- a/tests/test_load.cxx
+++ b/tests/test_load.cxx
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "helpers.hxx"
 #include "vm.hxx"
 
 template <typename CellT>
@@ -37,7 +38,7 @@ static void test_load_file() {
     std::vector<CellT> cells(1, 0);
     size_t ptr = 0;
     std::string out = runFile<CellT>(fname, cells, ptr, "A");
-    assert(out == "A");
+    assert(hashOutput(out) == 0x13099d40d095b684ULL);
     assert(cells[0] == static_cast<CellT>('A'));
     std::remove(fname);
 }


### PR DESCRIPTION
## Summary
- Link xxHash into test targets and add helper to hash output strings
- Compare test output hashes instead of literals

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bda66a1a8883318c146d460baf1155