### PR TITLE
Reserve space for local instructions

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -643,6 +643,7 @@ int executeImpl(std::vector<CellT>& cells, size_t& cellPtr, std::string& code, b
                 int eof, MemoryModel model, bool adaptive, size_t span, goof2::ProfileInfo* profile,
                 std::vector<instruction>* cached) {
     std::vector<instruction> localInstructions;
+    localInstructions.reserve(code.size());
     auto* instructionsPtr = cached ? cached : &localInstructions;
     bool hasInstructions = cached && !cached->empty();
     auto& instructions = *instructionsPtr;


### PR DESCRIPTION
## Summary
- Reserve capacity for local instruction buffer to match code length

## Testing
- `cmake -S . -B build` (pass)
- `cmake --build build` (interrupted: build took too long)
- `ctest --test-dir build` (not run: build failed)


------
https://chatgpt.com/codex/tasks/task_e_68bda93e2ef483318925989108eff888