### PR TITLE
Reserve cell capacity for dynamic memory

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -1838,6 +1838,9 @@ int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code
     bool adaptive = (model == MemoryModel::Auto);
     if (adaptive) model = MemoryModel::Contiguous;
     size_t predictedSpan = std::max(spanInfo.span, cells.size());
+    if (dynamicSize) {
+        cells.reserve(predictedSpan);
+    }
 
     // Heuristic: choose model based on predicted bytes to keep memory usage low.
     if (dynamicSize && adaptive) {


### PR DESCRIPTION
## Summary
- reserve predicted cell span when dynamic memory is enabled

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0c957ac8331b23d34ecf474db68