### PR TITLE
Mark thread pool interfaces noexcept

### DIFF
--- a/include/threadPool.hxx
+++ b/include/threadPool.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <exception>
 #include <functional>
 #include <future>
 #include <mutex>
@@ -13,11 +14,11 @@ namespace goof2 {
 
 class ThreadPool {
    public:
-    explicit ThreadPool(std::size_t count = std::thread::hardware_concurrency());
-    ~ThreadPool();
+    explicit ThreadPool(std::size_t count = std::thread::hardware_concurrency()) noexcept;
+    ~ThreadPool() noexcept;
 
     template <class F, class... Args>
-    auto submit(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>>;
+    auto submit(F&& f, Args&&... args) noexcept -> std::future<std::invoke_result_t<F, Args...>>;
 
    private:
     std::vector<std::thread> workers;
@@ -27,48 +28,65 @@ class ThreadPool {
     bool stop = false;
 };
 
-inline ThreadPool::ThreadPool(std::size_t count) {
+inline ThreadPool::ThreadPool(std::size_t count) noexcept {
     if (count == 0) count = 1;
     for (std::size_t i = 0; i < count; ++i) {
-        workers.emplace_back([this] {
-            for (;;) {
-                std::function<void()> task;
-                {
-                    std::unique_lock lock(queueMutex);
-                    condition.wait(lock, [this] { return stop || !tasks.empty(); });
-                    if (stop && tasks.empty()) return;
-                    task = std::move(tasks.front());
-                    tasks.pop();
+        try {
+            workers.emplace_back([this] {
+                for (;;) {
+                    std::function<void()> task;
+                    {
+                        std::unique_lock lock(queueMutex);
+                        condition.wait(lock, [this] { return stop || !tasks.empty(); });
+                        if (stop && tasks.empty()) return;
+                        task = std::move(tasks.front());
+                        tasks.pop();
+                    }
+                    task();
                 }
-                task();
-            }
-        });
+            });
+        } catch (...) {
+            // swallow exception to preserve noexcept
+        }
     }
 }
 
-inline ThreadPool::~ThreadPool() {
-    {
-        std::lock_guard lock(queueMutex);
-        stop = true;
-    }
-    condition.notify_all();
-    for (auto& w : workers) {
-        if (w.joinable()) w.join();
+inline ThreadPool::~ThreadPool() noexcept {
+    try {
+        {
+            std::lock_guard lock(queueMutex);
+            stop = true;
+        }
+        condition.notify_all();
+        for (auto& w : workers) {
+            if (w.joinable()) {
+                w.join();
+            }
+        }
+    } catch (...) {
+        // swallow exception to preserve noexcept
     }
 }
 
 template <class F, class... Args>
-auto ThreadPool::submit(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>> {
+auto ThreadPool::submit(F&& f, Args&&... args) noexcept
+    -> std::future<std::invoke_result_t<F, Args...>> {
     using Ret = std::invoke_result_t<F, Args...>;
-    auto task = std::make_shared<std::packaged_task<Ret()>>(
-        std::bind(std::forward<F>(f), std::forward<Args>(args)...));
-    auto fut = task->get_future();
-    {
-        std::lock_guard lock(queueMutex);
-        tasks.emplace([task]() mutable { (*task)(); });
+    try {
+        auto task = std::make_shared<std::packaged_task<Ret()>>(
+            std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+        auto fut = task->get_future();
+        {
+            std::lock_guard lock(queueMutex);
+            tasks.emplace([task]() mutable { (*task)(); });
+        }
+        condition.notify_one();
+        return fut;
+    } catch (...) {
+        std::promise<Ret> promise;
+        promise.set_exception(std::current_exception());
+        return promise.get_future();
     }
-    condition.notify_one();
-    return fut;
 }
 
 }  // namespace goof2


### PR DESCRIPTION
## Summary
- add noexcept guarantees to ThreadPool constructor, destructor, and submit
- guard internal operations so exceptions do not escape

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0d8a3bc8331b94a67d67d3ce0c7