### PR TITLE
Reserve tape capacity for contiguous and Fibonacci models

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -1923,10 +1923,6 @@ int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code
     bool adaptive = (model == MemoryModel::Auto);
     if (adaptive) model = MemoryModel::Contiguous;
     size_t predictedSpan = std::max(spanInfo.span, cells.size());
-    if (dynamicSize) {
-        cells.reserve(predictedSpan);
-    }
-
     // Heuristic: choose model based on predicted bytes to keep memory usage low.
     if (dynamicSize && adaptive) {
         const size_t predictedBytes = predictedSpan * sizeof(CellT);
@@ -1939,6 +1935,10 @@ int goof2::execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code
             model = MemoryModel::Paged;
         else if (predictedBytes > (size_t(1) << 20))
             model = MemoryModel::Fibonacci;
+    }
+    if (dynamicSize && !sparse &&
+        (model == MemoryModel::Contiguous || model == MemoryModel::Fibonacci)) {
+        cells.reserve(predictedSpan);
     }
     if (dynamicSize) {
         if (sparse) {


### PR DESCRIPTION
## Summary
- reserve predicted cell span only for contiguous and Fibonacci memory models
- skip reservation for sparse and OS-backed tapes to avoid unnecessary allocations

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `/usr/bin/time -v ./build/goof2 -i bench.bf -dts -mm contiguous`
- `/usr/bin/time -v ./build/goof2 -i bench.bf -dts -mm os`


------
https://chatgpt.com/codex/tasks/task_e_68bdb57773408331878fd9ebd482e49a