### PR TITLE
Remove code coverage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,16 +99,9 @@ if(MINGW)
     set(CMAKE_CXX_ARCHIVE_FINISH      "<CMAKE_RANLIB> <TARGET>" CACHE STRING "" FORCE)
 endif()
 
-option(BUILD_COVERAGE "Enable coverage reporting" OFF)
 option(GOOF2_ENABLE_REPL "Enable interactive REPL" ON)
 option(GOOF2_BUILD_TESTS "Build unit and fuzz tests" ON)
 
-if(BUILD_COVERAGE
-        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
-        AND NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    add_compile_options(--coverage -O0 -g)
-    add_link_options(--coverage)
-endif()
 #Default to a Release build if no build type is explicitly set.This keeps
 #binaries small and enables the high - optimization flags defined below.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -394,20 +387,3 @@ else()
     message(STATUS "Valgrind not found; 'memcheck' target will be unavailable")
 endif()
 
-if(BUILD_COVERAGE)
-    find_program(LCOV_EXE lcov)
-    find_program(GENHTML_EXE genhtml)
-    if(LCOV_EXE AND GENHTML_EXE)
-        add_custom_target(coverage
-            DEPENDS vm_execute_tests
-            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-            COMMAND ${LCOV_EXE} --capture --directory . --output-file coverage.info
-            COMMAND ${LCOV_EXE} --remove coverage.info '/usr/*' --output-file coverage.info
-            COMMAND ${GENHTML_EXE} coverage.info --output-directory coverage
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMENT "Run tests and generate coverage report"
-        )
-    else()
-        message(WARNING "lcov not found; coverage target will not be available")
-    endif()
-endif()

--- a/README.md
+++ b/README.md
@@ -30,21 +30,6 @@ cmake --build build --config Release
 ANSI escape sequences are enabled automatically on startup so colored
 output works in both PowerShell and `cmd.exe`.
 
-## Code coverage
-
-Builds can optionally collect code coverage information using `gcov` and
-`lcov`. First ensure `lcov` is installed on the system (for example,
-`apt-get install lcov` on Debian-based systems) and then configure the
-project with coverage enabled:
-
-```sh
-cmake -S . -B build -G Ninja -DBUILD_COVERAGE=ON
-cmake --build build --target coverage
-```
-
-An HTML report will be generated in `build/coverage`. Open
-`build/coverage/index.html` in a browser to explore the coverage data.
-
 ## Memory checking (Valgrind)
 
 On platforms where Valgrind is available (e.g., Linux), you can run the

--- a/tests/fuzz_execute.cxx
+++ b/tests/fuzz_execute.cxx
@@ -137,23 +137,15 @@ int main() {
             }
             std::terminate();
         });
-        goof2::ProfileInfo profile;
         try {
             goof2::execute<uint8_t>(cells, ptr, code, true, 0, true, false,
-                                    goof2::MemoryModel::Auto, &profile);
+                                    goof2::MemoryModel::Auto, nullptr);
         } catch (...) {
         }
         done = true;
         watchdogThread.join();
         std::cin.rdbuf(cinBuf);
         std::cout.rdbuf(coutBuf);
-        std::ofstream covFile("coverage.jsonl", std::ios::app);
-        covFile << "{\"program\":\"" << code << "\",\"coverage\":[";
-        for (size_t j = 0; j < profile.loopCounts.size(); ++j) {
-            if (j) covFile << ',';
-            covFile << profile.loopCounts[j];
-        }
-        covFile << "]}\n";
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- drop all build and documentation references to gcov/lcov coverage
- stop fuzz tests from emitting coverage.jsonl

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68bdcbffc97c83319c92cbe6c6b337da