### PR TITLE
Vectorize scan loops with SSE2

### DIFF
--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -658,8 +658,8 @@ static inline size_t simdScan0FwdAny(const CellT* p, const CellT* end, unsigned 
             int m = simde_mm_movemask_epi8(cmp);
             m = compressMask16<Bytes>(m);
             if (m) {
-                unsigned idx = tzcnt32(static_cast<unsigned>(m));
-                return off + idx * step;
+                unsigned lane = tzcnt32(static_cast<unsigned>(m)) / Bytes;
+                return off + lane * step;
             }
             x += step * lanes;
             off += step * lanes;
@@ -702,8 +702,8 @@ static inline size_t simdScan0BackAny(const CellT* base, const CellT* p, unsigne
             int m = simde_mm_movemask_epi8(cmp);
             m = compressMask16<Bytes>(m);
             if (m) {
-                unsigned idx = tzcnt32(static_cast<unsigned>(m));
-                return back + idx * step;
+                unsigned lane = tzcnt32(static_cast<unsigned>(m)) / Bytes;
+                return back + lane * step;
             }
             x -= step * lanes;
             back += step * lanes;


### PR DESCRIPTION
## Summary
- include SSE2 intrinsics and add generic SIMD helpers for arbitrary scan strides
- use SIMD helpers in _SCN_RGT and _SCN_LFT, replacing scalar loops
- fix lane index computation when reducing SIMD masks

## Testing
- `cmake -S . -B build -G Ninja` *(fails: reference is not a tree: bab7e27f4c6ae4efbb83dd99ae8a554423571635)*
- `cmake --build build` *(fails: loading 'build.ninja': No such file or directory)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06db843a88331b43c1c4f211516ca