### PR TITLE
Use SIMD to build sparse tape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ target_link_libraries(goof2 PRIVATE
 )
 if(GOOF2_ENABLE_REPL)
     target_link_libraries(goof2 PRIVATE linenoise)
-    target_include_directories(goof2 PRIVATE ${LINENOISE_SOURCE_DIR}/include)
+    target_include_directories(goof2 PRIVATE ${LINENOISE_SOURCE_DIR}/include ${SIMDE_INCLUDE_DIR})
     if (WIN32)
 #Needed for CommandLineToArgvW on MinGW / Windows builds
         target_link_libraries(goof2 PRIVATE shell32)


### PR DESCRIPTION
## Summary
- use SIMDe AVX2 to detect non-zero cells when creating sparse tapes
- add simde include path for the CLI target

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`
- `build/tests/repl_benchmark`
- `cmake -S . -B build_scalar -G Ninja -DCMAKE_CXX_FLAGS="-DSIMDE_NO_NATIVE"`
- `cmake --build build_scalar --target repl_benchmark`
- `build_scalar/tests/repl_benchmark`


------
https://chatgpt.com/codex/tasks/task_e_68c17969c0a48331b5450d2fefe7e9e4