### PR TITLE
Refactor VM into optimizer, memory, and executor modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
 endif()
 project(goof2 LANGUAGES C CXX)
 
-# Suppress noisy warnings originating from third-party CMake projects.
+#Suppress noisy warnings originating from third - party CMake projects.
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "" FORCE)
 
@@ -203,7 +203,7 @@ if(IS_DIRECTORY ${XXHASH_SOURCE_DIR} AND EXISTS ${XXHASH_SOURCE_DIR}/xxhash.h)
         target_include_directories(xxhash INTERFACE ${XXHASH_SOURCE_DIR})
     endif()
 else()
-    # xxhash commit from tag v0.8.3
+#xxhash commit from tag v0.8.3
     set(XXHASH_COMMIT e626a72bc2321cd320e953a0ccf1584cad60f363)
     if(GIT_PROGRAM)
         FetchContent_Declare(xxhash
@@ -228,9 +228,14 @@ endif()
 
 set(PCH_HEADER include/pch.hxx)
 set(VM_SOURCES
-    src/vm.cxx
+    src/vm/executor.cxx
+    src/vm/memory.cxx
+    src/vm/optimizer.cxx
     src/loop_cache.cxx
     include/vm.hxx
+    include/vm/memory.hxx
+    include/vm/optimizer.hxx
+    include/vm/executor.hxx
 )
 
 add_library(vm ${VM_SOURCES})
@@ -263,8 +268,8 @@ set(PROJECT_SOURCES ${EXEC_SOURCES} ${VM_SOURCES} ${PCH_HEADER})
 add_executable(goof2
     ${EXEC_SOURCES}
 )
-# Build a dedicated PCH for the executable to avoid flag-mismatch warnings
-# when the exe uses different compile flags than the vm library.
+#Build a dedicated PCH for the executable to avoid flag - mismatch warnings
+#when the exe uses different compile flags than the vm library.
 target_precompile_headers(goof2 PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/${PCH_HEADER}>")
 
 target_link_libraries(goof2 PRIVATE

--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -28,6 +28,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "vm/memory.hxx"
+
 enum class insType : uint8_t {
     ADD_SUB,
     SET,
@@ -55,10 +57,6 @@ struct instruction {
 };
 
 namespace goof2 {
-#if GOOF2_HAS_OS_VM
-extern void* (*os_alloc)(size_t);
-extern void (*os_free)(void*, size_t);
-#endif
 
 enum class MemoryModel { Auto, Contiguous, Fibonacci, Paged, OSBacked };
 
@@ -83,32 +81,6 @@ using LoopCache = std::unordered_map<std::uint64_t, std::vector<instruction>>;
 LoopCache& getLoopCache();
 std::mutex& getLoopCacheMutex();
 void clearLoopCache();
-
-/// @brief Only function you should use in your code. For now, it always prints to stdout.
-/// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
-/// @param cells Vector of cells of type CellT.
-/// @param cellPtr
-/// @param code Remember that this will be modified, so if you need to do something else with your
-/// plaintext code, make a copy.
-/// @param optimize Enable optimizations (highly recommended). Set it here as an override, for the
-/// default state, check the GOOF2_OPTIMIZE define.
-/// @param eof EOF behaviour. 0 = cell unchanged, 1 = set to 0, 2 = set to 255. Check
-/// GOOF2_DEFAULT_EOF_BEHAVIOUR.
-/// @param dynamicSize Allow dynamic resizing of the cells vector. Disable if you want, for example,
-/// a constant number of decimals for a calculation, constant cell vector size. OOB on fixed size is
-/// currently not handled.
-/// @param term A few tweaks necessary to make it operable multiple times on the same cells. Check
-/// GOOF2_DEFAULT_SAVE_STATE.
-/// @param model Memory allocation strategy. `Auto` selects a model heuristically.
-///
-/// When dynamicSize is enabled the engine heuristically selects between a contiguous
-/// growth strategy, a Fibonacci-sized expansion scheme and a page-sized allocation
-/// model for better performance on large tape sizes.
-/// @return
-template <typename CellT>
-int execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
-            bool optimize = GOOF2_OPTIMIZE, int eof = GOOF2_DEFAULT_EOF_BEHAVIOUR,
-            bool dynamicSize = GOOF2_DYNAMIC_CELLS_SIZE, bool term = GOOF2_DEFAULT_SAVE_STATE,
-            MemoryModel model = MemoryModel::Auto, ProfileInfo* profile = nullptr,
-            InstructionCache* cache = nullptr);
 }  // namespace goof2
+
+#include "vm/executor.hxx"

--- a/include/vm/executor.hxx
+++ b/include/vm/executor.hxx
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace goof2 {
+enum class MemoryModel;
+struct ProfileInfo;
+struct CacheEntry;
+using InstructionCache = std::unordered_map<size_t, CacheEntry>;
+
+/// @brief Only function you should use in your code. For now, it always prints to stdout.
+/// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
+/// @param cells Vector of cells of type CellT.
+/// @param cellPtr
+/// @param code Remember that this will be modified, so if you need to do something else with your
+/// plaintext code, make a copy.
+/// @param optimize Enable optimizations (highly recommended). Set it here as an override, for the
+/// default state, check the GOOF2_OPTIMIZE define.
+/// @param eof EOF behaviour. 0 = cell unchanged, 1 = set to 0, 2 = set to 255. Check
+/// GOOF2_DEFAULT_EOF_BEHAVIOUR.
+/// @param dynamicSize Allow dynamic resizing of the cells vector. Disable if you want, for example,
+/// a constant number of decimals for a calculation, constant cell vector size. OOB on fixed size is
+/// currently not handled.
+/// @param term A few tweaks necessary to make it operable multiple times on the same cells. Check
+/// GOOF2_DEFAULT_SAVE_STATE.
+/// @param model Memory allocation strategy. `Auto` selects a model heuristically.
+///
+/// When dynamicSize is enabled the engine heuristically selects between a contiguous
+/// growth strategy, a Fibonacci-sized expansion scheme and a page-sized allocation
+/// model for better performance on large tape sizes.
+/// @return
+template <typename CellT>
+int execute(std::vector<CellT>& cells, size_t& cellPtr, std::string& code,
+            bool optimize = GOOF2_OPTIMIZE, int eof = GOOF2_DEFAULT_EOF_BEHAVIOUR,
+            bool dynamicSize = GOOF2_DYNAMIC_CELLS_SIZE, bool term = GOOF2_DEFAULT_SAVE_STATE,
+            MemoryModel model = MemoryModel::Auto, ProfileInfo* profile = nullptr,
+            InstructionCache* cache = nullptr);
+}  // namespace goof2

--- a/include/vm/memory.hxx
+++ b/include/vm/memory.hxx
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+namespace goof2 {
+#if GOOF2_HAS_OS_VM
+void* defaultOsAlloc(size_t bytes);
+void defaultOsFree(void* ptr, size_t bytes);
+extern void* (*os_alloc)(size_t);
+extern void (*os_free)(void*, size_t);
+#endif
+}  // namespace goof2

--- a/include/vm/optimizer.hxx
+++ b/include/vm/optimizer.hxx
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory_resource>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using SvMatch = std::match_results<std::string_view::const_iterator>;
+
+namespace goof2 {
+
+struct CountingResource : std::pmr::memory_resource {
+    std::pmr::memory_resource* upstream;
+    std::size_t bytes = 0;
+
+    explicit CountingResource(std::pmr::memory_resource* up = std::pmr::new_delete_resource())
+        : upstream(up) {}
+
+   private:
+    void* do_allocate(std::size_t s, std::size_t align) override {
+        bytes += s;
+        return upstream->allocate(s, align);
+    }
+    void do_deallocate(void* p, std::size_t s, std::size_t align) override {
+        upstream->deallocate(p, s, align);
+    }
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+        return this == &other;
+    }
+};
+
+inline std::string processBalanced(std::string_view s, char no1, char no2) {
+    const auto total = std::ranges::count(s, no1) - std::ranges::count(s, no2);
+    return std::string(std::abs(total), total > 0 ? no1 : no2);
+}
+
+template <typename Callback>
+inline void regexReplaceInplace(std::string& str, const std::regex& re, Callback cb) {
+    std::string_view sv{str};
+    using Iterator = std::string_view::const_iterator;
+
+    std::regex_iterator<Iterator> it(sv.begin(), sv.end(), re), end;
+    if (it == end) return;
+
+    std::string result;
+    result.reserve(str.size());
+
+    Iterator last = sv.begin();
+    do {
+        const SvMatch& m = *it;
+        result.append(last, m[0].first);
+        result += cb(m);
+        last = m[0].second;
+    } while (++it != end);
+    result.append(last, sv.end());
+    str = std::move(result);
+}
+
+struct RegexReplacement {
+    size_t start;
+    size_t end;
+    std::string text;
+    std::function<void()> sideEffect;
+};
+
+template <typename Callback>
+inline std::pmr::vector<RegexReplacement> regexCollect(const std::string& str, const std::regex& re,
+                                                       Callback cb, std::pmr::memory_resource* mr) {
+    std::pmr::vector<RegexReplacement> reps{mr};
+    reps.reserve(std::max<size_t>(8, str.size() / 16));
+    std::string_view sv{str};
+    using Iterator = std::string_view::const_iterator;
+    for (std::regex_iterator<Iterator> it(sv.begin(), sv.end(), re), end; it != end; ++it) {
+        const SvMatch& m = *it;
+        auto [rep, eff] = cb(m);
+        reps.push_back({static_cast<size_t>(m[0].first - sv.begin()),
+                        static_cast<size_t>(m[0].second - sv.begin()), std::move(rep),
+                        std::move(eff)});
+    }
+    return reps;
+}
+
+namespace vmRegex {
+using namespace std::regex_constants;
+extern const std::regex nonInstructionRe;
+extern const std::regex balanceSeqRe;
+extern const std::regex clearLoopRe;
+extern const std::regex scanLoopClrRe;
+extern const std::regex scanLoopRe;
+extern const std::regex commaTrimRe;
+extern const std::regex clearThenSetRe;
+extern const std::regex copyLoopRe;
+extern const std::regex leadingSetRe;
+extern const std::regex copyLoopInnerRe;
+extern const std::regex clearSeqRe;
+extern const std::regex clearPassRe;
+}  // namespace vmRegex
+
+}  // namespace goof2

--- a/src/vm/memory.cxx
+++ b/src/vm/memory.cxx
@@ -1,0 +1,36 @@
+#include "vm/memory.hxx"
+
+#include "vm.hxx"
+
+#if GOOF2_HAS_OS_VM
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+namespace goof2 {
+#if defined(_WIN32)
+void* defaultOsAlloc(size_t bytes) {
+    const size_t maxReserve = static_cast<size_t>(GOOF2_TAPE_MAX_BYTES);
+    void* base = VirtualAlloc(nullptr, maxReserve, MEM_RESERVE, PAGE_READWRITE);
+    if (base) {
+        void* commit = VirtualAlloc(base, bytes, MEM_COMMIT, PAGE_READWRITE);
+        if (commit) return base;
+        VirtualFree(base, 0, MEM_RELEASE);
+    }
+    return VirtualAlloc(nullptr, bytes, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+}
+void defaultOsFree(void* ptr, size_t) { VirtualFree(ptr, 0, MEM_RELEASE); }
+#else
+void* defaultOsAlloc(size_t bytes) {
+    return mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+}
+void defaultOsFree(void* ptr, size_t bytes) { munmap(ptr, bytes); }
+#endif
+
+void* (*os_alloc)(size_t) = defaultOsAlloc;
+void (*os_free)(void*, size_t) = defaultOsFree;
+}  // namespace goof2
+#endif

--- a/src/vm/optimizer.cxx
+++ b/src/vm/optimizer.cxx
@@ -1,0 +1,17 @@
+#include "vm/optimizer.hxx"
+
+namespace goof2::vmRegex {
+using namespace std::regex_constants;
+const std::regex nonInstructionRe(R"([^+\-<>\.,\]\[])", optimize | nosubs);
+const std::regex balanceSeqRe(R"([+-]{2,}|[><]{2,})", optimize | nosubs);
+const std::regex clearLoopRe(R"([+-]*\[[+-]+\](?:\[[+-]+\])*)", optimize | nosubs);
+const std::regex scanLoopClrRe(R"(\[-[<>]+\]|\[[<>]\[-\]\])", optimize | nosubs);
+const std::regex scanLoopRe(R"(\[[<>]+\])", optimize | nosubs);
+const std::regex commaTrimRe(R"([+\-C]+,)", optimize | nosubs);
+const std::regex clearThenSetRe(R"(C([+-]+))", optimize);
+const std::regex copyLoopRe(R"(\[-((?:[<>]+[+-]+)+)[<>]+\]|\[((?:[<>]+[+-]+)+)[<>]+-\])", optimize);
+const std::regex leadingSetRe(R"((?:^|([RL\]]))C*([\+\-]+))", optimize);
+const std::regex copyLoopInnerRe(R"((?:<+|>+)[+-]+)", optimize | nosubs);
+const std::regex clearSeqRe(R"(C{2,})", optimize | nosubs);
+const std::regex clearPassRe(R"((C([+-]+))|C{2,})", optimize);
+}  // namespace goof2::vmRegex


### PR DESCRIPTION
## Summary
- modularize VM by splitting memory handling, execution, and optimization utilities
- add dedicated headers under include/vm and source files under src/vm
- update build configuration for new VM components
- restore execute function documentation in executor header

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c18b253d24833190ca8d2187cca442